### PR TITLE
Refactorize API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ QGIS_IMAGE=$(REGISTRY_PREFIX)qgis-platform:$(FLAVOR)
 
 LOCAL_HOME ?= $(shell pwd)
 
+# Checke setup.cfg for flake8 configuration
+lint:
+	@flake8
+
 test:
 	mkdir -p $$(pwd)/.local $(LOCAL_HOME)/.cache
 	docker run --rm --name qgis-py-server-test-$(COMMITID) -w /src \

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Once installed, the `wmtscache` cache command can be used to manage the cache co
 - list cache content infos
 - delete project cache content
 - delete specific layer cached tiles  
- 
+
 ## WMTS Cache manager API
 
 The WMTS Cache manager API provides these URLs:

--- a/README.md
+++ b/README.md
@@ -53,20 +53,20 @@ Once installed, the `wmtscache` cache command can be used to manage the cache co
 ## WMTS Cache manager API
 
 The WMTS Cache manager API provides these URLs:
-* /cachemngr.json
+* /cachemngr/?
   * to get information on the WMTS disk cache
-* /cachemngr/collections.json
+* /cachemngr/collections/?
   * to get the list of collections, QGIS projects, that have WMTS disk cache
-* /cachemngr/collection/(?<collectionId>[^/]+?).json
+* /cachemngr/collection/(?<collectionId>[^/]+)/?
   * to get information on a collection, QGIS project, WMTS disk cache
   * to delete the collection, QGIS Project, WMTS disk cache
-* /cachemngr/collection/(?<collectionId>[^/]+?)/docs.json
+* /cachemngr/collection/(?<collectionId>[^/]+)/docs/?
   * to get information on a collection, QGIS project, WMTS documents disk cache
   * to delete the collection, QGIS Project, WMTS documents disk cache
-* /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
+* /cachemngr/collection/(?<collectionId>[^/]+)/layers/?
   * to get information on a collection, QGIS project, WMTS layers tiles disk cache
   * to delete the collection, QGIS Project, WMTS layers tiles disk cache
-* /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+* /cachemngr/collection/(?<collectionId>[^/]+)/layers/(?<layerid>[^/]+)/?
   * to get information on a collection, QGIS project, WMTS layer tiles disk cache
   * to delete the collection, QGIS Project, WMTS layer tiles disk cache
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,25 @@ Once installed, the `wmtscache` cache command can be used to manage the cache co
 - list cache content infos
 - delete project cache content
 - delete specific layer cached tiles  
+ 
+## WMTS Cache manager API
+
+The WMTS Cache manager API provides these URLs:
+* /cachemngr.json
+  * to get information on the WMTS disk cache
+* /cachemngr/collections.json
+  * to get the list of collections, QGIS projects, that have WMTS disk cache
+* /cachemngr/collection/(?<collectionId>[^/]+?).json
+  * to get information on a collection, QGIS project, WMTS disk cache
+  * to delete the collection, QGIS Project, WMTS disk cache
+* /cachemngr/collection/(?<collectionId>[^/]+?)/docs.json
+  * to get information on a collection, QGIS project, WMTS documents disk cache
+  * to delete the collection, QGIS Project, WMTS documents disk cache
+* /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
+  * to get information on a collection, QGIS project, WMTS layers tiles disk cache
+  * to delete the collection, QGIS Project, WMTS layers tiles disk cache
+* /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+  * to get information on a collection, QGIS project, WMTS layer tiles disk cache
+  * to delete the collection, QGIS Project, WMTS layer tiles disk cache
+
+To delete some cache, you have to use Delete HTTP method over the dedicated URL.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,43 +2,17 @@
 max-line-length = 130
 max-complexity = 16
 
-ignore =
-    # E111 indentation is not a multiple of 4
-    E111,
-    # Closing bracket does not match visual indentation
-    E124,
-    E125,
-    E126,
-    E128,
-    # E201 202, missing white space before ( )
-    E201,
-    E202,
-    E203,
-    # E221 multiple spaces before operator
-    E221,
-    # E225 missing whitespace around operator
-    E225,
-    # E231 missing whitespace after ','
-    E231,
-    # E241 multiple spaces after ','
-    E241,
-    # E251 unexpected spaces around keyword / parameter equals
-    E251,
-    # E252 missing whitespace around parameter equals
-    E252,
-    # E302 expected 2 blank lines
-    E302,
-    # E241 multiple spaces after ','
-    E241,
-    # E731 do not assign a lambda expression, use a def
-    E731,
+ignore = E123,E2,E3,E5,W2,W3
 
 exclude =
     .git,
+    .github,
     .venv,
     venv,
     __pycache__,
     tests/conftest.py,
+    .local,
+    .cache,
 
 [isort]
 multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ ignore =
     E231,
     # E241 multiple spaces after ','
     E241,
+    # E251 unexpected spaces around keyword / parameter equals
+    E251,
     # E252 missing whitespace around parameter equals
     E252,
     # E302 expected 2 blank lines

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ logging.disable(logging.NOTSET)
 LOGGER = logging.getLogger('server')
 LOGGER.setLevel(logging.DEBUG)
 
-from typing import Any, Dict, Generator, Mapping
+from typing import Any, Dict, Generator
 
 from qgis.core import Qgis, QgsApplication, QgsFontUtils, QgsProject
 from qgis.server import (
@@ -146,10 +146,25 @@ def client(request):
             self.server.handleRequest(request, response, project=qgsproject)
             return OWSResponse(response)
 
+        def delete(self, query: str, project: str=None) -> OWSResponse:
+            """ Return server response from query
+            """
+            request  = QgsBufferServerRequest(query, QgsServerRequest.DeleteMethod, {}, None)
+            response = QgsBufferServerResponse()
+            if project is not None and not os.path.isabs(project):
+                projectpath = self.datapath.join(project)
+                qgsproject  = QgsProject()
+                if not qgsproject.read(projectpath.strpath):
+                    raise ValueError("Error reading project '%s':" % projectpath.strpath)
+            else:
+                qgsproject = None
+            self.server.handleRequest(request, response, project=qgsproject)
+            return OWSResponse(response)
+
     return _Client()
 
 
-## 
+##
 ## Plugins
 ##
 

--- a/tests/test_wmts_cache.py
+++ b/tests/test_wmts_cache.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+from pathlib import Path
 
 import lxml.etree
 
@@ -130,6 +131,9 @@ def test_wmts_document_cache_time(client):
 
     assert projmtime < ndocmtime
     assert docmtime < ndocmtime
+
+    # Clean files after testing
+    Path(client.getprojectpath("france_parts_copy.qgs")).unlink()
 
 
 def test_wmts_document_tile(client):

--- a/tests/test_wmts_cache.py
+++ b/tests/test_wmts_cache.py
@@ -31,9 +31,9 @@ def test_wmts_document_cache(client):
     assert not os.path.exists(docroot.as_posix())
 
     parameters = {
-            'MAP': project.fileName(),
-            'REQUEST': 'GetCapabilities',
-            'SERVICE': 'WMTS'
+        'MAP': project.fileName(),
+        'REQUEST': 'GetCapabilities',
+        'SERVICE': 'WMTS'
     }
 
     # Get the cached path from the request parameters
@@ -91,9 +91,9 @@ def test_wmts_document_cache_time(client):
     assert not os.path.exists(docroot.as_posix())
 
     parameters = {
-            'MAP': project.fileName(),
-            'REQUEST': 'GetCapabilities',
-            'SERVICE': 'WMTS'
+        'MAP': project.fileName(),
+        'REQUEST': 'GetCapabilities',
+        'SERVICE': 'WMTS'
     }
 
     # Get the cached path from the request parameters
@@ -157,17 +157,17 @@ def test_wmts_document_tile(client):
     assert not os.path.exists(tileroot.as_posix())
 
     parameters = {
-            "MAP": project.fileName(),
-            "SERVICE": "WMTS",
-            "VERSION": "1.0.0",
-            "REQUEST": "GetTile",
-            "LAYER": "france_parts",
-            "STYLE": "",
-            "TILEMATRIXSET": "EPSG:4326",
-            "TILEMATRIX": "0",
-            "TILEROW": "0",
-            "TILECOL": "0",
-            "FORMAT": "image/png"
+        "MAP": project.fileName(),
+        "SERVICE": "WMTS",
+        "VERSION": "1.0.0",
+        "REQUEST": "GetTile",
+        "LAYER": "france_parts",
+        "STYLE": "",
+        "TILEMATRIXSET": "EPSG:4326",
+        "TILEMATRIX": "0",
+        "TILEROW": "0",
+        "TILECOL": "0",
+        "FORMAT": "image/png"
     }
 
     # Get the cached path from the request parameters

--- a/tests/test_wmts_cachemngrapi.py
+++ b/tests/test_wmts_cachemngrapi.py
@@ -1,0 +1,853 @@
+import sys
+import os
+import logging
+import json
+import lxml.etree
+
+from shutil import rmtree
+
+from qgis.core import Qgis, QgsProject
+from qgis.server import (QgsBufferServerRequest,
+                         QgsBufferServerResponse)
+
+LOGGER = logging.getLogger('server')
+
+
+def test_wmts_cachemngrapi_empty_cache(client):
+    """ Test the API with empty cache
+        /cachemngr.json
+        /cachemngr/collections.json
+    """
+    # Get plugin
+    plugin = client.getplugin('wmtsCacheServer')
+    assert plugin is not None
+
+    # Clear cache
+    for c in plugin.rootpath.glob('*.inf'):
+        rmtree(c.with_suffix(''))
+        c.unlink()
+
+    # Make a request
+    qs = "/cachemngr.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'links' in json_content
+    assert len(json_content['links']) == 1
+    assert json_content['links'][0]['title'] == 'Cache collections'
+
+    qs = "/cachemngr/collections.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'cache_layout' in json_content
+    assert json_content['cache_layout'] == 'tc'
+    assert 'collections' in json_content
+    assert len(json_content['collections']) == 0
+    assert 'links' in json_content
+
+
+def test_wmts_cachemngrapi_cache_info(client):
+    """ Test the API with cache
+        /cachemngr.json
+        /cachemngr/collections.json
+        /cachemngr/collection/(?<collectionId>[^/]+?).json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/docs.json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+    """
+    plugin = client.getplugin('wmtsCacheServer')
+    assert plugin is not None
+
+    # Create a filter
+    cachefilter = plugin.create_filter()
+
+    # Delete document
+    project = QgsProject()
+    project.setFileName(client.getprojectpath("france_parts.qgs").strpath)
+
+    # Get project document root path
+    docroot = cachefilter._cache.get_documents_root(project.fileName())
+
+    cachefilter.deleteCachedDocuments(project)
+
+    assert not os.path.exists(docroot.as_posix())
+
+    parameters = {
+        'MAP': project.fileName(),
+        'REQUEST': 'GetCapabilities',
+        'SERVICE': 'WMTS'
+    }
+
+    # Get the cached path from the request parameters
+    docpath = cachefilter._cache.get_document_cache(project.fileName(), parameters,'.xml').as_posix()
+
+    assert not os.path.exists(docpath)
+
+    # Make a request
+    qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
+    rv = client.get(qs, project.fileName())
+    assert rv.status_code == 200
+
+    # Test that document cache has been created
+    assert os.path.exists(docpath)
+
+    # Get project tiles root path
+    tileroot = cachefilter._cache.get_tiles_root(project.fileName())
+
+    cachefilter.deleteCachedImages(project)
+
+    assert not os.path.exists(tileroot.as_posix())
+
+    parameters = {
+            "MAP": project.fileName(),
+            "SERVICE": "WMTS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetTile",
+            "LAYER": "france_parts",
+            "STYLE": "",
+            "TILEMATRIXSET": "EPSG:4326",
+            "TILEMATRIX": "0",
+            "TILEROW": "0",
+            "TILECOL": "0",
+            "FORMAT": "image/png" }
+
+    # Get the cached path from the request parameters
+    tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
+
+    assert not os.path.exists(tilepath)
+
+    # Make a request
+    qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
+    rv = client.get(qs, project.fileName())
+
+    original_content = rv.content
+
+    if rv.status_code != 200:
+        LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))
+
+    assert rv.status_code == 200
+
+    # Test that document cache has been created
+    assert os.path.exists(tilepath)
+
+    # Cache manager API requests
+    qs = "/cachemngr/collections.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'cache_layout' in json_content
+    assert json_content['cache_layout'] == 'tc'
+
+    assert 'collections' in json_content
+    assert len(json_content['collections']) == 1
+
+    assert 'links' in json_content
+    assert len(json_content['links']) == 0
+
+    collection = json_content['collections'][0]
+    assert 'id' in collection
+    assert 'links' in collection
+    assert 'project' in collection
+    assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    qs = "/cachemngr/collections/{}.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'project' in json_content
+    assert json_content['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    assert 'links' in json_content
+    assert len(json_content['links']) == 2
+
+    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'project' in json_content
+    assert json_content['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    assert 'documents' in json_content
+    assert json_content['documents'] == 1
+
+    assert 'links' in json_content
+    assert len(json_content['links']) == 0
+
+    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'project' in json_content
+    assert json_content['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    assert 'layers' in json_content
+    assert len(json_content['layers']) == 1
+
+    assert 'links' in json_content
+    assert len(json_content['links']) == 0
+
+    layer = json_content['layers'][0]
+    assert 'id' in layer
+    assert 'links' in layer
+
+    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], layer['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == layer['id']
+
+    assert 'links' in json_content
+    assert len(json_content['links']) == 0
+
+
+def test_wmts_cachemngrapi_delete_docs(client):
+    """ Test the API with to remove docs cache
+        /cachemngr/collections.json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/docs.json
+    """
+    plugin = client.getplugin('wmtsCacheServer')
+    assert plugin is not None
+
+    # Create a filter
+    cachefilter = plugin.create_filter()
+
+    # Delete document
+    project = QgsProject()
+    project.setFileName(client.getprojectpath("france_parts.qgs").strpath)
+
+    # Get project document root path
+    docroot = cachefilter._cache.get_documents_root(project.fileName())
+
+    cachefilter.deleteCachedDocuments(project)
+
+    assert not os.path.exists(docroot.as_posix())
+
+    parameters = {
+        'MAP': project.fileName(),
+        'REQUEST': 'GetCapabilities',
+        'SERVICE': 'WMTS'
+    }
+
+    # Get the cached path from the request parameters
+    docpath = cachefilter._cache.get_document_cache(project.fileName(), parameters,'.xml').as_posix()
+
+    assert not os.path.exists(docpath)
+
+    # Make a request
+    qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
+    rv = client.get(qs, project.fileName())
+    assert rv.status_code == 200
+
+    # Test that document cache has been created
+    assert os.path.exists(docpath)
+
+    # Cache manager API requests
+    qs = "/cachemngr/collections.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'collections' in json_content
+    assert len(json_content['collections']) == 1
+
+    collection = json_content['collections'][0]
+    assert 'id' in collection
+    assert 'links' in collection
+    assert 'project' in collection
+    assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    # Get docs info
+    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'project' in json_content
+    assert json_content['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    assert 'documents' in json_content
+    assert json_content['documents'] == 1
+
+    # Delete docs
+    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    rv = client.delete(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    # Get docs info
+    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'project' in json_content
+    assert json_content['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    assert 'documents' in json_content
+    assert json_content['documents'] == 0
+
+    # Test that document cache has been deleted
+    assert not os.path.exists(docpath)
+
+
+def test_wmts_cachemngrapi_delete_layer(client):
+    """ Test the API with to remove docs cache
+        /cachemngr/collections.json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+    """
+    plugin = client.getplugin('wmtsCacheServer')
+    assert plugin is not None
+
+    # Create a filter
+    cachefilter = plugin.create_filter()
+
+    # Delete document
+    project = QgsProject()
+    project.setFileName(client.getprojectpath("france_parts.qgs").strpath)
+
+    # Get project tiles root path
+    tileroot = cachefilter._cache.get_tiles_root(project.fileName())
+
+    cachefilter.deleteCachedImages(project)
+
+    assert not os.path.exists(tileroot.as_posix())
+
+    parameters = {
+            "MAP": project.fileName(),
+            "SERVICE": "WMTS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetTile",
+            "LAYER": "france_parts",
+            "STYLE": "",
+            "TILEMATRIXSET": "EPSG:4326",
+            "TILEMATRIX": "0",
+            "TILEROW": "0",
+            "TILECOL": "0",
+            "FORMAT": "image/png" }
+
+    # Get the cached path from the request parameters
+    tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
+
+    assert not os.path.exists(tilepath)
+
+    # Make a request
+    qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
+    rv = client.get(qs, project.fileName())
+
+    original_content = rv.content
+
+    if rv.status_code != 200:
+        LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))
+
+    assert rv.status_code == 200
+
+    # Test that document cache has been created
+    assert os.path.exists(tilepath)
+
+    # Cache manager API requests
+    qs = "/cachemngr/collections.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'collections' in json_content
+    assert len(json_content['collections']) == 1
+
+    collection = json_content['collections'][0]
+    assert 'id' in collection
+    assert 'links' in collection
+    assert 'project' in collection
+    assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'layers' in json_content
+    assert len(json_content['layers']) == 1
+
+    layer = json_content['layers'][0]
+    assert 'id' in layer
+
+    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], layer['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == layer['id']
+
+    # Delete layer tiles
+    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], layer['id'])
+    rv = client.delete(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    # Get layer tiles info
+    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], layer['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 404
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    # Get layers info
+    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'layers' in json_content
+    assert len(json_content['layers']) == 0
+
+    # Test that tiles cache has been deleted
+    assert not os.path.exists(tilepath)
+
+def test_wmts_cachemngrapi_delete_layers(client):
+    """ Test the API with to remove docs cache
+        /cachemngr/collections.json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
+    """
+    plugin = client.getplugin('wmtsCacheServer')
+    assert plugin is not None
+
+    # Create a filter
+    cachefilter = plugin.create_filter()
+
+    # Delete tiles
+    project = QgsProject()
+    project.setFileName(client.getprojectpath("france_parts.qgs").strpath)
+
+    # Get project tiles root path
+    tileroot = cachefilter._cache.get_tiles_root(project.fileName())
+
+    cachefilter.deleteCachedImages(project)
+
+    assert not os.path.exists(tileroot.as_posix())
+
+    parameters = {
+            "MAP": project.fileName(),
+            "SERVICE": "WMTS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetTile",
+            "LAYER": "france_parts",
+            "STYLE": "",
+            "TILEMATRIXSET": "EPSG:4326",
+            "TILEMATRIX": "0",
+            "TILEROW": "0",
+            "TILECOL": "0",
+            "FORMAT": "image/png" }
+
+    # Get the cached path from the request parameters
+    tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
+
+    assert not os.path.exists(tilepath)
+
+    # Make a request
+    qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
+    rv = client.get(qs, project.fileName())
+
+    original_content = rv.content
+
+    if rv.status_code != 200:
+        LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))
+
+    assert rv.status_code == 200
+
+    # Test that tile cache has been created
+    assert os.path.exists(tilepath)
+
+    # Cache manager API requests
+    qs = "/cachemngr/collections.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'collections' in json_content
+    assert len(json_content['collections']) == 1
+
+    collection = json_content['collections'][0]
+    assert 'id' in collection
+    assert 'links' in collection
+    assert 'project' in collection
+    assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    # Get layers info
+    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'layers' in json_content
+    assert len(json_content['layers']) == 1
+
+    # Delete layers tiles
+    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    rv = client.delete(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    # Get layers info
+    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'layers' in json_content
+    assert len(json_content['layers']) == 0
+
+    # Test that tiles cache has been deleted
+    assert not os.path.exists(tilepath)
+
+
+def test_wmts_cachemngrapi_delete_collection(client):
+    """ Test the API with to remove docs cache
+        /cachemngr/collections.json
+        /cachemngr/collection/(?<collectionId>[^/]+?).json
+    """
+    plugin = client.getplugin('wmtsCacheServer')
+    assert plugin is not None
+
+    # Create a filter
+    cachefilter = plugin.create_filter()
+
+    # Delete document
+    project = QgsProject()
+    project.setFileName(client.getprojectpath("france_parts.qgs").strpath)
+
+    # Get project document root path
+    docroot = cachefilter._cache.get_documents_root(project.fileName())
+
+    cachefilter.deleteCachedDocuments(project)
+
+    assert not os.path.exists(docroot.as_posix())
+
+    parameters = {
+        'MAP': project.fileName(),
+        'REQUEST': 'GetCapabilities',
+        'SERVICE': 'WMTS'
+    }
+
+    # Get the cached path from the request parameters
+    docpath = cachefilter._cache.get_document_cache(project.fileName(), parameters,'.xml').as_posix()
+
+    assert not os.path.exists(docpath)
+
+    # Make a request
+    qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
+    rv = client.get(qs, project.fileName())
+    assert rv.status_code == 200
+
+    # Test that document cache has been created
+    assert os.path.exists(docpath)
+
+    # Get project tiles root path
+    tileroot = cachefilter._cache.get_tiles_root(project.fileName())
+
+    cachefilter.deleteCachedImages(project)
+
+    assert not os.path.exists(tileroot.as_posix())
+
+    parameters = {
+            "MAP": project.fileName(),
+            "SERVICE": "WMTS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetTile",
+            "LAYER": "france_parts",
+            "STYLE": "",
+            "TILEMATRIXSET": "EPSG:4326",
+            "TILEMATRIX": "0",
+            "TILEROW": "0",
+            "TILECOL": "0",
+            "FORMAT": "image/png" }
+
+    # Get the cached path from the request parameters
+    tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
+
+    assert not os.path.exists(tilepath)
+
+    # Make a request
+    qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
+    rv = client.get(qs, project.fileName())
+
+    original_content = rv.content
+
+    if rv.status_code != 200:
+        LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))
+
+    assert rv.status_code == 200
+
+    # Test that document cache has been created
+    assert os.path.exists(tilepath)
+
+    # Cache manager API requests
+    qs = "/cachemngr/collections.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'collections' in json_content
+    assert len(json_content['collections']) == 1
+
+    collection = json_content['collections'][0]
+    assert 'id' in collection
+    assert 'links' in collection
+    assert 'project' in collection
+    assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    # Get docs info
+    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'project' in json_content
+    assert json_content['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    assert 'documents' in json_content
+    assert json_content['documents'] == 1
+
+    # Get layers info
+    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'layers' in json_content
+    assert len(json_content['layers']) == 1
+
+    # Delete collection documents and layers tiles
+    qs = "/cachemngr/collections/{}.json".format(collection['id'])
+    rv = client.delete(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    # Get docs info
+    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 404
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    # Test that document cache has been deleted
+    assert not os.path.exists(docpath)
+
+    # Get layers info
+    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 404
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    # Test that tiles cache has been deleted
+    assert not os.path.exists(tilepath)
+
+    # Get collections info
+    qs = "/cachemngr/collections.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'collections' in json_content
+    assert len(json_content['collections']) == 0
+
+
+def test_wmts_cachemngrapi_layerid_error(client):
+    """ Test the API with empty cache
+        /cachemngr/collection/(?<collectionId>[^/]+?).json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+    """
+
+    plugin = client.getplugin('wmtsCacheServer')
+    assert plugin is not None
+
+    # Create a filter
+    cachefilter = plugin.create_filter()
+
+    # Delete tiles
+    project = QgsProject()
+    project.setFileName(client.getprojectpath("france_parts.qgs").strpath)
+
+    # Get project tiles root path
+    tileroot = cachefilter._cache.get_tiles_root(project.fileName())
+
+    cachefilter.deleteCachedImages(project)
+
+    assert not os.path.exists(tileroot.as_posix())
+
+    parameters = {
+            "MAP": project.fileName(),
+            "SERVICE": "WMTS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetTile",
+            "LAYER": "france_parts",
+            "STYLE": "",
+            "TILEMATRIXSET": "EPSG:4326",
+            "TILEMATRIX": "0",
+            "TILEROW": "0",
+            "TILECOL": "0",
+            "FORMAT": "image/png" }
+
+    # Get the cached path from the request parameters
+    tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
+
+    assert not os.path.exists(tilepath)
+
+    # Make a request
+    qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
+    rv = client.get(qs, project.fileName())
+
+    original_content = rv.content
+
+    if rv.status_code != 200:
+        LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))
+
+    assert rv.status_code == 200
+
+    # Test that tile cache has been created
+    assert os.path.exists(tilepath)
+
+    # Cache manager API requests
+    qs = "/cachemngr/collections.json"
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'collections' in json_content
+    assert len(json_content['collections']) == 1
+
+    collection = json_content['collections'][0]
+    assert 'id' in collection
+    assert 'links' in collection
+    assert 'project' in collection
+    assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
+
+    # Get layers info
+    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    rv = client.get(qs)
+    assert rv.status_code == 200
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'id' in json_content
+    assert json_content['id'] == collection['id']
+
+    assert 'layers' in json_content
+    assert len(json_content['layers']) == 1
+
+    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], 'foobar')
+    rv = client.delete(qs)
+    assert rv.status_code == 404
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'code' in json_content
+    assert json_content['code'] == 'API not found error'
+
+
+def test_wmts_cachemngrapi_collectionid_error(client):
+    """ Test the API with empty cache
+        /cachemngr/collection/(?<collectionId>[^/]+?).json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/docs.json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
+        /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+    """
+
+    qs = "/cachemngr/collections/{}.json".format('foobar')
+    rv = client.delete(qs)
+    assert rv.status_code == 404
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'code' in json_content
+    assert json_content['code'] == 'API not found error'
+
+    qs = "/cachemngr/collections/{}/docs.json".format('foobar')
+    rv = client.delete(qs)
+    assert rv.status_code == 404
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'code' in json_content
+    assert json_content['code'] == 'API not found error'
+
+    qs = "/cachemngr/collections/{}/layers.json".format('foobar')
+    rv = client.delete(qs)
+    assert rv.status_code == 404
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'code' in json_content
+    assert json_content['code'] == 'API not found error'
+
+    qs = "/cachemngr/collections/{0}/layers/{0}.json".format('foobar')
+    rv = client.delete(qs)
+    assert rv.status_code == 404
+    assert rv.headers.get('Content-Type') == 'application/json'
+
+    json_content = json.loads(rv.content)
+    assert 'code' in json_content
+    assert json_content['code'] == 'API not found error'

--- a/tests/test_wmts_cachemngrapi.py
+++ b/tests/test_wmts_cachemngrapi.py
@@ -1,14 +1,12 @@
-import sys
-import os
-import logging
 import json
-import lxml.etree
+import logging
+import os
 
 from shutil import rmtree
 
-from qgis.core import Qgis, QgsProject
-from qgis.server import (QgsBufferServerRequest,
-                         QgsBufferServerResponse)
+import lxml.etree
+
+from qgis.core import QgsProject
 
 LOGGER = logging.getLogger('server')
 
@@ -125,7 +123,7 @@ def test_wmts_cachemngrapi_cache_info(client):
     qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
     rv = client.get(qs, project.fileName())
 
-    original_content = rv.content
+    # original_content = rv.content
 
     if rv.status_code != 200:
         LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))
@@ -369,7 +367,7 @@ def test_wmts_cachemngrapi_delete_layer(client):
     qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
     rv = client.get(qs, project.fileName())
 
-    original_content = rv.content
+    # original_content = rv.content
 
     if rv.status_code != 200:
         LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))
@@ -491,7 +489,7 @@ def test_wmts_cachemngrapi_delete_layers(client):
     qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
     rv = client.get(qs, project.fileName())
 
-    original_content = rv.content
+    # original_content = rv.content
 
     if rv.status_code != 200:
         LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))
@@ -623,7 +621,7 @@ def test_wmts_cachemngrapi_delete_collection(client):
     qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
     rv = client.get(qs, project.fileName())
 
-    original_content = rv.content
+    # original_content = rv.content
 
     if rv.status_code != 200:
         LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))
@@ -759,7 +757,7 @@ def test_wmts_cachemngrapi_layerid_error(client):
     qs = "?" + "&".join("%s=%s" % item for item in parameters.items())
     rv = client.get(qs, project.fileName())
 
-    original_content = rv.content
+    # original_content = rv.content
 
     if rv.status_code != 200:
         LOGGER.error(lxml.etree.tostring(rv.xml, pretty_print=True))

--- a/tests/test_wmts_cachemngrapi.py
+++ b/tests/test_wmts_cachemngrapi.py
@@ -13,8 +13,8 @@ LOGGER = logging.getLogger('server')
 
 def test_wmts_cachemngrapi_empty_cache(client):
     """ Test the API with empty cache
-        /cachemngr.json
-        /cachemngr/collections.json
+        /wmtscache
+        /wmtscache/collections
     """
     # Get plugin
     plugin = client.getplugin('wmtsCacheServer')
@@ -26,20 +26,20 @@ def test_wmts_cachemngrapi_empty_cache(client):
         c.unlink()
 
     # Make a request
-    qs = "/cachemngr.json"
+    qs = "/wmtscache"
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'links' in json_content
     assert len(json_content['links']) == 1
     assert json_content['links'][0]['title'] == 'Cache collections'
 
-    qs = "/cachemngr/collections.json"
+    qs = "/wmtscache/collections"
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'cache_layout' in json_content
@@ -51,12 +51,12 @@ def test_wmts_cachemngrapi_empty_cache(client):
 
 def test_wmts_cachemngrapi_cache_info(client):
     """ Test the API with cache
-        /cachemngr.json
-        /cachemngr/collections.json
-        /cachemngr/collection/(?<collectionId>[^/]+?).json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/docs.json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+        /wmtscache
+        /wmtscache/collections
+        /wmtscache/collection/(?<collectionId>[^/]+?)
+        /wmtscache/collection/(?<collectionId>[^/]+?)/docs
+        /wmtscache/collection/(?<collectionId>[^/]+?)/layers
+        /wmtscache/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?)
     """
     plugin = client.getplugin('wmtsCacheServer')
     assert plugin is not None
@@ -102,17 +102,18 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert not os.path.exists(tileroot.as_posix())
 
     parameters = {
-            "MAP": project.fileName(),
-            "SERVICE": "WMTS",
-            "VERSION": "1.0.0",
-            "REQUEST": "GetTile",
-            "LAYER": "france_parts",
-            "STYLE": "",
-            "TILEMATRIXSET": "EPSG:4326",
-            "TILEMATRIX": "0",
-            "TILEROW": "0",
-            "TILECOL": "0",
-            "FORMAT": "image/png" }
+        "MAP": project.fileName(),
+        "SERVICE": "WMTS",
+        "VERSION": "1.0.0",
+        "REQUEST": "GetTile",
+        "LAYER": "france_parts",
+        "STYLE": "",
+        "TILEMATRIXSET": "EPSG:4326",
+        "TILEMATRIX": "0",
+        "TILEROW": "0",
+        "TILECOL": "0",
+        "FORMAT": "image/png" 
+    }
 
     # Get the cached path from the request parameters
     tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
@@ -134,10 +135,10 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert os.path.exists(tilepath)
 
     # Cache manager API requests
-    qs = "/cachemngr/collections.json"
+    qs = "/wmtscache/collections"
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'cache_layout' in json_content
@@ -155,10 +156,10 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert 'project' in collection
     assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
 
-    qs = "/cachemngr/collections/{}.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -170,10 +171,10 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert 'links' in json_content
     assert len(json_content['links']) == 2
 
-    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/docs".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -188,10 +189,10 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert 'links' in json_content
     assert len(json_content['links']) == 0
 
-    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -210,10 +211,10 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert 'id' in layer
     assert 'links' in layer
 
-    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], layer['id'])
+    qs = "/wmtscache/collections/{}/layers/{}".format(collection['id'], layer['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -225,8 +226,8 @@ def test_wmts_cachemngrapi_cache_info(client):
 
 def test_wmts_cachemngrapi_delete_docs(client):
     """ Test the API with to remove docs cache
-        /cachemngr/collections.json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/docs.json
+        /wmtscache/collections
+        /wmtscache/collection/(?<collectionId>[^/]+?)/docs
     """
     plugin = client.getplugin('wmtsCacheServer')
     assert plugin is not None
@@ -265,10 +266,10 @@ def test_wmts_cachemngrapi_delete_docs(client):
     assert os.path.exists(docpath)
 
     # Cache manager API requests
-    qs = "/cachemngr/collections.json"
+    qs = "/wmtscache/collections"
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'collections' in json_content
@@ -281,10 +282,10 @@ def test_wmts_cachemngrapi_delete_docs(client):
     assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
 
     # Get docs info
-    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/docs".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -297,16 +298,15 @@ def test_wmts_cachemngrapi_delete_docs(client):
     assert json_content['documents'] == 1
 
     # Delete docs
-    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/docs".format(collection['id'])
     rv = client.delete(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
 
     # Get docs info
-    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/docs".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -324,9 +324,9 @@ def test_wmts_cachemngrapi_delete_docs(client):
 
 def test_wmts_cachemngrapi_delete_layer(client):
     """ Test the API with to remove docs cache
-        /cachemngr/collections.json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+        /wmtscache/collections
+        /wmtscache/collection/(?<collectionId>[^/]+?)/layers
+        /wmtscache/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?)
     """
     plugin = client.getplugin('wmtsCacheServer')
     assert plugin is not None
@@ -346,17 +346,18 @@ def test_wmts_cachemngrapi_delete_layer(client):
     assert not os.path.exists(tileroot.as_posix())
 
     parameters = {
-            "MAP": project.fileName(),
-            "SERVICE": "WMTS",
-            "VERSION": "1.0.0",
-            "REQUEST": "GetTile",
-            "LAYER": "france_parts",
-            "STYLE": "",
-            "TILEMATRIXSET": "EPSG:4326",
-            "TILEMATRIX": "0",
-            "TILEROW": "0",
-            "TILECOL": "0",
-            "FORMAT": "image/png" }
+        "MAP": project.fileName(),
+        "SERVICE": "WMTS",
+        "VERSION": "1.0.0",
+        "REQUEST": "GetTile",
+        "LAYER": "france_parts",
+        "STYLE": "",
+        "TILEMATRIXSET": "EPSG:4326",
+        "TILEMATRIX": "0",
+        "TILEROW": "0",
+        "TILECOL": "0",
+        "FORMAT": "image/png" 
+    }
 
     # Get the cached path from the request parameters
     tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
@@ -378,10 +379,10 @@ def test_wmts_cachemngrapi_delete_layer(client):
     assert os.path.exists(tilepath)
 
     # Cache manager API requests
-    qs = "/cachemngr/collections.json"
+    qs = "/wmtscache/collections"
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'collections' in json_content
@@ -393,10 +394,10 @@ def test_wmts_cachemngrapi_delete_layer(client):
     assert 'project' in collection
     assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
 
-    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -408,32 +409,31 @@ def test_wmts_cachemngrapi_delete_layer(client):
     layer = json_content['layers'][0]
     assert 'id' in layer
 
-    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], layer['id'])
+    qs = "/wmtscache/collections/{}/layers/{}".format(collection['id'], layer['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
     assert json_content['id'] == layer['id']
 
     # Delete layer tiles
-    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], layer['id'])
+    qs = "/wmtscache/collections/{}/layers/{}".format(collection['id'], layer['id'])
     rv = client.delete(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
 
     # Get layer tiles info
-    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], layer['id'])
+    qs = "/wmtscache/collections/{}/layers/{}".format(collection['id'], layer['id'])
     rv = client.get(qs)
     assert rv.status_code == 404
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     # Get layers info
-    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -447,8 +447,8 @@ def test_wmts_cachemngrapi_delete_layer(client):
 
 def test_wmts_cachemngrapi_delete_layers(client):
     """ Test the API with to remove docs cache
-        /cachemngr/collections.json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
+        /wmtscache/collections
+        /wmtscache/collection/(?<collectionId>[^/]+?)/layers
     """
     plugin = client.getplugin('wmtsCacheServer')
     assert plugin is not None
@@ -468,17 +468,18 @@ def test_wmts_cachemngrapi_delete_layers(client):
     assert not os.path.exists(tileroot.as_posix())
 
     parameters = {
-            "MAP": project.fileName(),
-            "SERVICE": "WMTS",
-            "VERSION": "1.0.0",
-            "REQUEST": "GetTile",
-            "LAYER": "france_parts",
-            "STYLE": "",
-            "TILEMATRIXSET": "EPSG:4326",
-            "TILEMATRIX": "0",
-            "TILEROW": "0",
-            "TILECOL": "0",
-            "FORMAT": "image/png" }
+        "MAP": project.fileName(),
+        "SERVICE": "WMTS",
+        "VERSION": "1.0.0",
+        "REQUEST": "GetTile",
+        "LAYER": "france_parts",
+        "STYLE": "",
+        "TILEMATRIXSET": "EPSG:4326",
+        "TILEMATRIX": "0",
+        "TILEROW": "0",
+        "TILECOL": "0",
+        "FORMAT": "image/png" 
+    }
 
     # Get the cached path from the request parameters
     tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
@@ -500,10 +501,10 @@ def test_wmts_cachemngrapi_delete_layers(client):
     assert os.path.exists(tilepath)
 
     # Cache manager API requests
-    qs = "/cachemngr/collections.json"
+    qs = "/wmtscache/collections"
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'collections' in json_content
@@ -516,10 +517,10 @@ def test_wmts_cachemngrapi_delete_layers(client):
     assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
 
     # Get layers info
-    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -529,16 +530,15 @@ def test_wmts_cachemngrapi_delete_layers(client):
     assert len(json_content['layers']) == 1
 
     # Delete layers tiles
-    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.delete(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
 
     # Get layers info
-    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -553,8 +553,8 @@ def test_wmts_cachemngrapi_delete_layers(client):
 
 def test_wmts_cachemngrapi_delete_collection(client):
     """ Test the API with to remove docs cache
-        /cachemngr/collections.json
-        /cachemngr/collection/(?<collectionId>[^/]+?).json
+        /wmtscache/collections
+        /wmtscache/collection/(?<collectionId>[^/]+?)
     """
     plugin = client.getplugin('wmtsCacheServer')
     assert plugin is not None
@@ -600,17 +600,18 @@ def test_wmts_cachemngrapi_delete_collection(client):
     assert not os.path.exists(tileroot.as_posix())
 
     parameters = {
-            "MAP": project.fileName(),
-            "SERVICE": "WMTS",
-            "VERSION": "1.0.0",
-            "REQUEST": "GetTile",
-            "LAYER": "france_parts",
-            "STYLE": "",
-            "TILEMATRIXSET": "EPSG:4326",
-            "TILEMATRIX": "0",
-            "TILEROW": "0",
-            "TILECOL": "0",
-            "FORMAT": "image/png" }
+        "MAP": project.fileName(),
+        "SERVICE": "WMTS",
+        "VERSION": "1.0.0",
+        "REQUEST": "GetTile",
+        "LAYER": "france_parts",
+        "STYLE": "",
+        "TILEMATRIXSET": "EPSG:4326",
+        "TILEMATRIX": "0",
+        "TILEROW": "0",
+        "TILECOL": "0",
+        "FORMAT": "image/png" 
+    }
 
     # Get the cached path from the request parameters
     tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
@@ -632,10 +633,10 @@ def test_wmts_cachemngrapi_delete_collection(client):
     assert os.path.exists(tilepath)
 
     # Cache manager API requests
-    qs = "/cachemngr/collections.json"
+    qs = "/wmtscache/collections"
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'collections' in json_content
@@ -648,10 +649,10 @@ def test_wmts_cachemngrapi_delete_collection(client):
     assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
 
     # Get docs info
-    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/docs".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -664,10 +665,10 @@ def test_wmts_cachemngrapi_delete_collection(client):
     assert json_content['documents'] == 1
 
     # Get layers info
-    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -677,34 +678,33 @@ def test_wmts_cachemngrapi_delete_collection(client):
     assert len(json_content['layers']) == 1
 
     # Delete collection documents and layers tiles
-    qs = "/cachemngr/collections/{}.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}".format(collection['id'])
     rv = client.delete(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
 
     # Get docs info
-    qs = "/cachemngr/collections/{}/docs.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/docs".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 404
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     # Test that document cache has been deleted
     assert not os.path.exists(docpath)
 
     # Get layers info
-    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 404
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     # Test that tiles cache has been deleted
     assert not os.path.exists(tilepath)
 
     # Get collections info
-    qs = "/cachemngr/collections.json"
+    qs = "/wmtscache/collections"
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'collections' in json_content
@@ -713,9 +713,9 @@ def test_wmts_cachemngrapi_delete_collection(client):
 
 def test_wmts_cachemngrapi_layerid_error(client):
     """ Test the API with empty cache
-        /cachemngr/collection/(?<collectionId>[^/]+?).json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+        /wmtscache/collection/(?<collectionId>[^/]+?)
+        /wmtscache/collection/(?<collectionId>[^/]+?)/layers
+        /wmtscache/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?)
     """
 
     plugin = client.getplugin('wmtsCacheServer')
@@ -736,17 +736,18 @@ def test_wmts_cachemngrapi_layerid_error(client):
     assert not os.path.exists(tileroot.as_posix())
 
     parameters = {
-            "MAP": project.fileName(),
-            "SERVICE": "WMTS",
-            "VERSION": "1.0.0",
-            "REQUEST": "GetTile",
-            "LAYER": "france_parts",
-            "STYLE": "",
-            "TILEMATRIXSET": "EPSG:4326",
-            "TILEMATRIX": "0",
-            "TILEROW": "0",
-            "TILECOL": "0",
-            "FORMAT": "image/png" }
+        "MAP": project.fileName(),
+        "SERVICE": "WMTS",
+        "VERSION": "1.0.0",
+        "REQUEST": "GetTile",
+        "LAYER": "france_parts",
+        "STYLE": "",
+        "TILEMATRIXSET": "EPSG:4326",
+        "TILEMATRIX": "0",
+        "TILEROW": "0",
+        "TILECOL": "0",
+        "FORMAT": "image/png" 
+    }
 
     # Get the cached path from the request parameters
     tilepath = cachefilter._cache.get_tile_cache(project.fileName(),parameters).as_posix()
@@ -768,10 +769,10 @@ def test_wmts_cachemngrapi_layerid_error(client):
     assert os.path.exists(tilepath)
 
     # Cache manager API requests
-    qs = "/cachemngr/collections.json"
+    qs = "/wmtscache/collections"
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'collections' in json_content
@@ -784,10 +785,10 @@ def test_wmts_cachemngrapi_layerid_error(client):
     assert collection['project'] == client.getprojectpath("france_parts.qgs").strpath
 
     # Get layers info
-    qs = "/cachemngr/collections/{}/layers.json".format(collection['id'])
+    qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.get(qs)
     assert rv.status_code == 200
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
     assert 'id' in json_content
@@ -796,56 +797,56 @@ def test_wmts_cachemngrapi_layerid_error(client):
     assert 'layers' in json_content
     assert len(json_content['layers']) == 1
 
-    qs = "/cachemngr/collections/{}/layers/{}.json".format(collection['id'], 'foobar')
+    qs = "/wmtscache/collections/{}/layers/{}".format(collection['id'], 'foobar')
     rv = client.delete(qs)
     assert rv.status_code == 404
-    assert rv.headers.get('Content-Type') == 'application/json'
 
     json_content = json.loads(rv.content)
-    assert 'code' in json_content
-    assert json_content['code'] == 'API not found error'
+    assert 'error' in json_content
+    assert json_content['error'].get('message') == "Layer 'foobar' not found"
 
 
 def test_wmts_cachemngrapi_collectionid_error(client):
     """ Test the API with empty cache
-        /cachemngr/collection/(?<collectionId>[^/]+?).json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/docs.json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/layers.json
-        /cachemngr/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?).json
+        /wmtscache/collection/(?<collectionId>[^/]+?)
+        /wmtscache/collection/(?<collectionId>[^/]+?)/docs
+        /wmtscache/collection/(?<collectionId>[^/]+?)/layers
+        /wmtscache/collection/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?)
     """
 
-    qs = "/cachemngr/collections/{}.json".format('foobar')
+    qs = "/wmtscache/collections/{}".format('foobar')
     rv = client.delete(qs)
     assert rv.status_code == 404
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
-    assert 'code' in json_content
-    assert json_content['code'] == 'API not found error'
+    assert 'error' in json_content
+    assert json_content['error'].get('message') == "Collection 'foobar' not found"
 
-    qs = "/cachemngr/collections/{}/docs.json".format('foobar')
+    qs = "/wmtscache/collections/{}/docs".format('foobar')
     rv = client.delete(qs)
     assert rv.status_code == 404
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
-    assert 'code' in json_content
-    assert json_content['code'] == 'API not found error'
+    assert 'error' in json_content
+    assert json_content['error'].get('message') == "Collection 'foobar' not found"
 
-    qs = "/cachemngr/collections/{}/layers.json".format('foobar')
+    qs = "/wmtscache/collections/{}/layers".format('foobar')
     rv = client.delete(qs)
     assert rv.status_code == 404
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
-    assert 'code' in json_content
-    assert json_content['code'] == 'API not found error'
+    assert 'error' in json_content
+    assert json_content['error'].get('message') == "Collection 'foobar' not found"
 
-    qs = "/cachemngr/collections/{0}/layers/{0}.json".format('foobar')
+    qs = "/wmtscache/collections/{0}/layers/{0}".format('foobar')
     rv = client.delete(qs)
     assert rv.status_code == 404
-    assert rv.headers.get('Content-Type') == 'application/json'
+    assert rv.headers.get('Content-Type',"").startswith('application/json')
 
     json_content = json.loads(rv.content)
-    assert 'code' in json_content
-    assert json_content['code'] == 'API not found error'
+    assert 'error' in json_content
+    assert json_content['error'].get('message') == "Collection 'foobar' not found"
+

--- a/wmtsCacheServer/apiutils.py
+++ b/wmtsCacheServer/apiutils.py
@@ -1,0 +1,264 @@
+""" QGIS server plugin filter - Cache WMTS output on disk
+
+    Qgis API utils utils
+
+    author: David Marteau (3liz)
+    Copyright: (C) 2019 3Liz
+"""
+import sys
+import json
+import traceback
+
+
+from pathlib import Path
+from http.client import responses as http_responses
+
+from typing import Any, Optional, Union, Tuple, Type, List, Dict
+
+from qgis.PyQt.QtCore import QRegularExpression, QUrl
+from qgis.server import (
+    QgsServerOgcApi,
+    QgsServerOgcApiHandler,
+    QgsServerRequest,
+)
+
+from qgis.core import Qgis, QgsMessageLog
+
+class HTTPError(Exception):
+
+    def __init__(self, status_code: int=500, log_message: Optional[str] = None,
+                 *args: Any, **kwargs: Any) -> None:
+        self.status_code = status_code
+        self.log_message = log_message
+        self.args = args
+        self.reason =  kwargs.get("reason", None)
+
+    def __str__(self) -> str:
+        message = "HTTP %d: %s" % (
+            self.status_code,
+            self.reason or http_responses.get(self.status_code, "Unknown"),
+        )
+        if self.log_message:
+            return message + " (" + (self.log_message % self.args) + ")"
+        else:
+            return message
+
+
+class RequestHandler:
+
+    def __init__(self, parent: QgsServerOgcApiHandler,  context) -> None:
+        self._parent   = parent
+        self._context  = context
+        self._response = context.response()
+        self._request  = context.request()
+        self._finished = False
+
+    def initialize(self, rootdir: Path, **kwargs: Any ) -> None:
+        """ May be overrided
+        """
+        self.rootdir = rootdir
+
+    def prepare(self, **values):
+        """
+        """
+        pass
+
+    def href(self, path: str="", extension: str="") -> str:
+        """ Returns an URL to self, to be used for links to the current resources 
+            and as a base for constructing links to sub-resources
+        """
+        return self._parent.href(self._context,path,extension)
+
+    def finish(self, chunk: Optional[Union[str, bytes, dict]] = None) -> None:
+        """ Terminate the request
+        """
+        if self._finished:
+            raise RuntimeError("finish() called twice")
+
+        if chunk is not None:
+            self.write(chunk)
+
+        self._finished = True
+
+    def write(self, chunk: Union[str, bytes, dict]) -> None:
+        """
+        """
+        if not isinstance(chunk, (bytes, str, dict)):
+            raise TypeError("write() only accepts bytes, unicode, and dict objects")
+        if isinstance(chunk, dict):
+            chunk = json.dumps(chunk, sort_keys=True)
+        self.set_header('Content-Type', 'application/json;charset=utf-8')
+        self._response.write(chunk)
+
+    def set_status(self, status_code: int, reason: Optional[str]=None) -> None:
+        """
+        """
+        self._response.setStatusCode(status_code)
+        if reason is not None:
+            self._reason = reason
+        else:
+            self._reason = http_responses.get(status_code, "Unknown")
+
+    def send_error(self, status_code: int = 500, **kwargs: Any) -> None:
+        """
+        """
+        self._response.clear()
+        reason = kwargs.get("reason")
+        if "exc_info" in kwargs:
+            exception = kwargs["exc_info"][1]
+            if isinstance(exception, HTTPError) and exception.reason:
+                reason = exception.reason
+        self.set_status(status_code, reason=reason)
+        self.write(dict(status="error" if status_code != 200 else "ok",
+                        httpcode = status_code,
+                        error    = { "message": self._reason }))
+        
+        if status_code > 300:
+            QgsMessageLog.logMessage(f"Returned HTTP Error {status_code}: {self._reason}" ,"wmtsCacheApi",Qgis.Critical)
+        
+        if not self._finished:
+            self.finish()
+
+    def set_header(self, name: str, value: str) -> None:
+        """
+        """
+        self._response.setHeader(name,value)
+
+    def _unimplemented_method(self, *args: str, **kwargs: str) -> None:
+        raise HTTPError(405)
+
+    head   = _unimplemented_method
+    get    = _unimplemented_method
+    post   = _unimplemented_method
+    delete = _unimplemented_method
+    patch  = _unimplemented_method
+    put    = _unimplemented_method
+
+    METHODS = {
+        QgsServerRequest.HeadMethod  : 'head',
+        QgsServerRequest.PutMethod   : 'put',
+        QgsServerRequest.GetMethod   : 'get',
+        QgsServerRequest.PostMethod  : 'post',
+        QgsServerRequest.PatchMethod : 'patch',
+        QgsServerRequest.DeleteMethod: 'delete',
+    }
+
+    def execute(self, values):
+        """ Execute the request
+        """
+        try:
+            method = self._request.method()
+            if method not in self.METHODS:
+                raise HTTPError(405)
+
+            self.prepare( **values )
+            if self._finished:
+                return
+
+            self.set_status(200)
+
+            method = getattr(self, self.METHODS[method])
+            method( **values )
+
+            if not self._finished:
+                self.finish()
+        except Exception as e:
+            if self._finished:
+                # Nothing to send, but log for debugging purpose
+                QgsMessageLog.logMessage(traceback.format_exc(),"wmtsCacheApi",Qgis.Critical)
+                return
+            if isinstance(e, HTTPError):
+                self.send_error(e.status_code, exc_info=sys.exc_info())
+            else:
+                QgsMessageLog.logMessage(traceback.format_exc(),"wmtsCacheApi", Qgis.Critical)
+                self.send_error(500, exc_info=sys.exc_info())
+
+
+
+class RequestHandlerDelegate(QgsServerOgcApiHandler):
+    """ Delegate request to handler
+    """
+
+    # XXX We need to preserve instances from garbage
+    # collection 
+    __instances = []
+
+    def __init__(self, path: str, handler: Type[RequestHandler],
+                 content_types=[QgsServerOgcApi.JSON,],
+                 kwargs: Dict={}):
+
+        super().__init__()
+        if content_types:
+            self.setContentTypes(content_types)
+        self._path = QRegularExpression(path)
+        self._name = handler.__name__
+        self._handler = handler
+        self._kwargs = kwargs
+
+        self.__instances.append(self)
+
+    def path(self):
+        return self._path
+
+    def linkType(self):
+        return QgsServerOgcApi.items
+
+    def operationId(self):
+        return f"WMTSCache{self._name}"
+
+    def summary(self):
+        return f"WMTS Cache manager {self._name}"
+
+    def description(self):
+        return f"WMTS Cache manager {self._name }"
+
+    def linkTitle(self):
+        return f"WMTS Cache manager {self._name }"
+
+    def templatePath(self, context):
+        # No templates!
+        return ''
+
+    def parameters(self, context):
+        return []
+
+    def handleRequest(self, context):
+        """ 
+        """
+        handler = self._handler(self,context)
+        handler.initialize(**self._kwargs)
+        handler.execute(self.values(context))
+
+
+class _ServerApi(QgsServerOgcApi):
+    """ Redefine Accept method as to get exact match
+    """
+    __instances = []
+
+    # See above
+    def __init__(self,*args,**kwargs):
+        super().__init__(*args,**kwargs)
+
+        self.__instances.append(self)
+
+    def accept(self, url: QUrl) -> bool:
+        """ Override the api to actually match the rootpath
+        """
+        return url.path().startswith( self.rootPath() )
+
+
+HandlerDefinition = Tuple[str,Type[RequestHandler],Dict]
+
+
+def register_api_handlers(serverIface, rootpath: str, name: str, handlers: List[HandlerDefinition],
+                          descripton: Optional[str]=None,
+                          version: Optional[str]=None) -> None:
+
+    api = _ServerApi(serverIface, rootpath, name, descripton, version)
+    for path,handler,kwargs in handlers:
+        content_types = kwargs.pop('content_types',[QgsServerOgcApi.JSON,])
+        api.registerHandler(RequestHandlerDelegate(path,handler,content_types=content_types,
+                                                   kwargs=kwargs))
+
+    serverIface.serviceRegistry().registerApi(api)
+

--- a/wmtsCacheServer/cachefilter.py
+++ b/wmtsCacheServer/cachefilter.py
@@ -28,7 +28,7 @@ Hash = TypeVar('Hash')
 
 @contextmanager
 def trap():
-    """ Define a trap context for catchinf exception
+    """ Define a trap context for catching exception
         and send them to error log
     """
     try:
@@ -99,8 +99,8 @@ class DiskCacheFilter(QgsServerCacheFilter):
         with trap():
             p = self.get_document_cache(project,request)
             if p.is_file():
-               p.unlink()
-               return True
+                p.unlink()
+                return True
 
         return False
 
@@ -119,7 +119,7 @@ class DiskCacheFilter(QgsServerCacheFilter):
         return self._cache.get_tile_cache(project.fileName(),request.parameters(),create_dir=create_dir)
 
     def setCachedImage(self, img: Union[QByteArray, bytes, bytearray],
-            project: 'QgsProject', request: 'QgsServerRequest', key: str) -> bool:
+                       project: 'QgsProject', request: 'QgsServerRequest', key: str) -> bool:
         """ Override QgsServerCacheFilter::setCachedImage
         """
         if request.parameters().get('SERVICE','').upper() == 'WMTS':
@@ -151,8 +151,8 @@ class DiskCacheFilter(QgsServerCacheFilter):
             with trap():
                 p = self.get_tile_cache(project,request)
                 if p.is_file():
-                   p.unlink()
-                   return True
+                    p.unlink()
+                    return True
 
         return False
 

--- a/wmtsCacheServer/cachemngr.py
+++ b/wmtsCacheServer/cachemngr.py
@@ -47,8 +47,8 @@ def match_projects( glob: str, data: dict ) -> List[str]:
     if glob == '*':
         return data
 
-    # E731 do not assign a lambda expression, use a def
-    match = lambda p: p.match(glob) or p.match(glob + '.qgs') or p.name == glob or p.name == glob + '.qgs'
+    def match( p ):
+        p.match(glob) or p.match(glob + '.qgs') or p.name == glob or p.name == glob + '.qgs'
 
     return { h:v for h,v in data.items() if match(Path(v['project'])) }
 

--- a/wmtsCacheServer/cachemngrapi.py
+++ b/wmtsCacheServer/cachemngrapi.py
@@ -3,18 +3,15 @@ import json
 from pathlib import Path
 from shutil import rmtree
 
-from qgis.PyQt.QtCore import (
-    QRegularExpression,
-)
-
+from qgis.PyQt.QtCore import QRegularExpression
 from qgis.server import (
-    QgsServerException,
-    QgsServerOgcApiHandler,
     QgsServerOgcApi,
+    QgsServerOgcApiHandler,
     QgsServerRequest,
 )
 
 from .helper import CacheHelper
+
 
 def read_metadata(rootdir: Path) -> dict:
     """ Read metadata
@@ -32,18 +29,18 @@ def read_metadata(rootdir: Path) -> dict:
         h = d.name
 
         tiledir = d / 'tiles'
-        layers = [l.name for l in tiledir.glob('*') if l.is_dir()]
+        layers = [layer.name for layer in tiledir.glob('*') if layer.is_dir()]
 
         data[h] = {
-           'project': c.read_text(),
-           'layers': layers,
+            'project': c.read_text(),
+            'layers': layers,
         }
-    #metadata.update(data=data)
+    # metadata.update(data=data)
     metadata['data'] = data
     return metadata
 
 
-class QgsServerApiException():
+class QgsServerApiException:
 
     def __init__(self, code, message, mime_type = 'application/json', response_code = 200):
         self.code = code
@@ -82,7 +79,7 @@ class CacheMngrApiHandler(QgsServerOgcApiHandler):
         resp_content, mime_type = ex.formatResponse()
         resp = context.response()
         resp.clear()
-        resp.setStatusCode(ex.responseCode());
+        resp.setStatusCode(ex.responseCode())
         resp.setHeader("Content-Type", mime_type)
         resp.write(resp_content)
 
@@ -91,7 +88,7 @@ class CacheMngrLandingPageHandler(CacheMngrApiHandler):
     """Project listing handler"""
 
     def path(self):
-        return QRegularExpression("(\.json|\.html|/)")
+        return QRegularExpression(r"(\.json|\.html|/)")
 
     def operationId(self):
         return "getLandingPage"
@@ -112,7 +109,7 @@ class CacheMngrLandingPageHandler(CacheMngrApiHandler):
         """List projects"""
 
         data = {
-            "links": [] #self.links(context)
+            "links": []  # self.links(context)
         }
         data['links'].append({
             "href": self.href(context, "/collections"),
@@ -140,7 +137,7 @@ class CacheMngrCollectionsHandler(CacheMngrApiHandler):
     """Project listing handler"""
 
     def path(self):
-        return QRegularExpression("/collections(\.json|\.html|/)")
+        return QRegularExpression(r"/collections(\.json|\.html|/)")
 
     def operationId(self):
         return "describeCollections"
@@ -165,7 +162,7 @@ class CacheMngrCollectionsHandler(CacheMngrApiHandler):
         data = {
             "cache_layout": metadata['layout'],
             "collections": [],
-            "links": [] #self.links(context),
+            "links": []  # self.links(context),
         }
 
         for h, v in metadata['data'].items():
@@ -202,7 +199,7 @@ class CacheMngrCollectionHandler(CacheMngrApiHandler):
     """Project listing handler"""
 
     def path(self):
-        return QRegularExpression("/collections/(?<collectionId>[^/]+?)(\.json|\.html|/)")
+        return QRegularExpression(r"/collections/(?<collectionId>[^/]+?)(\.json|\.html|/)")
 
     def operationId(self):
         return "describeCollection"
@@ -266,13 +263,17 @@ class CacheMngrCollectionHandler(CacheMngrApiHandler):
                     data['layers'].append({
                         'id': layer,
                         'links': [{
-                            "href": self.href(context, "/layers/{}".format(layer), QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                            "href": self.href(
+                                context,
+                                "/layers/{}".format(layer),
+                                QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)
+                            ),
                             "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
                             "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
                             "title": "Cache layer",
                         }]
                     })
-            data['links'] = [] #self.links(context)
+            data['links'] = []  # self.links(context)
             data['links'].append({
                 "href": self.href(context, "/docs", QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
                 "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
@@ -311,7 +312,7 @@ class CacheMngrCollectionDocsHandler(CacheMngrApiHandler):
     """Project listing handler"""
 
     def path(self):
-        return QRegularExpression("/collections/(?<collectionId>[^/]+?)/docs(\.json|\.html|/)")
+        return QRegularExpression(r"/collections/(?<collectionId>[^/]+?)/docs(\.json|\.html|/)")
 
     def operationId(self):
         return "describeDocs"
@@ -362,7 +363,7 @@ class CacheMngrCollectionDocsHandler(CacheMngrApiHandler):
                 data['id'] = h
                 data['project'] = project
                 data['documents'] = 0
-                data['links'] = [] #self.links(context)
+                data['links'] = []  # self.links(context)
 
                 docroot = cache.get_documents_root(project)
                 for _ in docroot.glob('*.xml'):
@@ -396,7 +397,7 @@ class CacheMngrCollectionLayersHandler(CacheMngrApiHandler):
     """Project listing handler"""
 
     def path(self):
-        return QRegularExpression("/collections/(?<collectionId>[^/]+?)/layers(\.json|\.html|/)")
+        return QRegularExpression(r"/collections/(?<collectionId>[^/]+?)/layers(\.json|\.html|/)")
 
     def operationId(self):
         return "describeLayers"
@@ -450,13 +451,17 @@ class CacheMngrCollectionLayersHandler(CacheMngrApiHandler):
                     data['layers'].append({
                         'id': layer,
                         'links': [{
-                            "href": self.href(context, "/layers/{}".format(layer), QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                            "href": self.href(
+                                context,
+                                "/layers/{}".format(layer),
+                                QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)
+                            ),
                             "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
                             "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
                             "title": "Cache layer",
                         }]
                     })
-                data['links'] = [] #self.links(context)
+                data['links'] = []  # self.links(context)
 
                 html_metadata = {
                     "pageTitle": self.linkTitle(),
@@ -486,7 +491,7 @@ class CacheMngrCollectionLayerHandler(CacheMngrApiHandler):
     """Project listing handler"""
 
     def path(self):
-        return QRegularExpression("/collections/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?)(\.json|\.html|/)")
+        return QRegularExpression(r"/collections/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?)(\.json|\.html|/)")
 
     def operationId(self):
         return "describeLayer"
@@ -541,7 +546,7 @@ class CacheMngrCollectionLayerHandler(CacheMngrApiHandler):
                 self.write(data, context)
             else:
                 data['id'] = layer_id
-                data['links'] = [] #self.links(context)
+                data['links'] = []  # self.links(context)
 
                 html_metadata = {
                     "pageTitle": self.linkTitle(),
@@ -568,6 +573,7 @@ class CacheMngrCollectionLayerHandler(CacheMngrApiHandler):
 
     def parameters(self, context):
         return []
+
 
 class CacheMngrApi(QgsServerOgcApi):
 

--- a/wmtsCacheServer/cachemngrapi.py
+++ b/wmtsCacheServer/cachemngrapi.py
@@ -3,588 +3,306 @@ import json
 from pathlib import Path
 from shutil import rmtree
 
-from qgis.PyQt.QtCore import QRegularExpression
-from qgis.server import (
-    QgsServerOgcApi,
-    QgsServerOgcApiHandler,
-    QgsServerRequest,
-)
+from typing import Optional, Tuple, Iterable, Dict
+
+from qgis.server import QgsServerOgcApi
+from qgis.core import Qgis, QgsMessageLog
 
 from .helper import CacheHelper
+from .apiutils import HTTPError, RequestHandler, register_api_handlers
 
 
-def read_metadata(rootdir: Path) -> dict:
+def read_wmts_metadata( rootdir ) -> Dict:
     """ Read metadata
     """
-
     metadata = rootdir / 'wmts.json'
     if not metadata.exists():
         raise Exception('Cannot read cache metadata!')
 
-    metadata = json.loads(metadata.read_text())
-
-    data = {}
-    for c in rootdir.glob('*.inf'):
-        d = c.with_suffix('')
-        h = d.name
-
-        tiledir = d / 'tiles'
-        layers = [layer.name for layer in tiledir.glob('*') if layer.is_dir()]
-
-        data[h] = {
-            'project': c.read_text(),
-            'layers': layers,
-        }
-    # metadata.update(data=data)
-    metadata['data'] = data
-    return metadata
+    return json.loads(metadata.read_text())
 
 
-class QgsServerApiException:
+def read_metadata_collection(rootdir: Path) -> Tuple[dict,Iterable]:
+    """ Read metadata
+    """
+    metadata = read_wmts_metadata(rootdir)
 
-    def __init__(self, code, message, mime_type = 'application/json', response_code = 200):
-        self.code = code
-        self.message = message
-        self.mime_type = mime_type
-        self.response_code = response_code
-
-    def formatResponse(self):
-        return json.dumps({
-            'code': self.code,
-            'description': self.what()
-        }), self.mime_type
-
-    def responseCode(self):
-        return self.response_code
-
-    def what(self):
-        return self.message
+    def collect():
+        for inf in rootdir.glob('*.inf'):
+            name = inf.with_suffix('').name
+            project = inf.read_text()
+            # (name, project)
+            yield (name,project)
+    
+    return (metadata, collect())
 
 
-class QgsServerApiNotFoundError(QgsServerApiException):
+def read_project_metadata( rootdir: Path, name: str ) -> Optional[Tuple[dict,Iterable]]:
+    """ Collect metadata about project
+    """
+    path = rootdir / f"{name}.inf"
+    if not path.exists():
+        raise FileNotFoundError(name)
 
-    def __init__(self, message, mime_type = 'application/json', response_code = 404):
-        super().__init__('API not found error', message, mime_type, response_code)
+    project = path.read_text()
 
-
-class CacheMngrApiHandler(QgsServerOgcApiHandler):
-
-    def __init__(self, rootdir):
-        super().__init__()
-        self.setContentTypes([QgsServerOgcApi.JSON, QgsServerOgcApi.HTML])
-
-        self.rootdir = rootdir
-
-    def sendException(self, ex, context):
-        resp_content, mime_type = ex.formatResponse()
-        resp = context.response()
-        resp.clear()
-        resp.setStatusCode(ex.responseCode())
-        resp.setHeader("Content-Type", mime_type)
-        resp.write(resp_content)
+    tiledir = path.with_suffix('') / "tiles"
+    layers  = (layer.name for layer in tiledir.glob('*') if layer.is_dir())
+    # (project, layers)
+    return (project, layers)
 
 
-class CacheMngrLandingPageHandler(CacheMngrApiHandler):
-    """Project listing handler"""
+#
+# WMTS API Handlers
+#
 
-    def path(self):
-        return QRegularExpression(r"(\.json|\.html|/)")
-
-    def operationId(self):
-        return "getLandingPage"
-
-    def summary(self):
-        return "WMTS Cache Manager landing page"
-
-    def description(self):
-        return "WMTS Cache Manager landing page"
-
-    def linkTitle(self):
-        return "WMTS Cache Manager landing page"
-
-    def linkType(self):
-        return QgsServerOgcApi.items
-
-    def handleRequest(self, context):
-        """List projects"""
-
+class LandingPage(RequestHandler):
+    """ Project collections listing handler
+    """
+    def get(self) -> None:
         data = {
-            "links": []  # self.links(context)
+            'links': [{
+                "href": self.href("/collections"),
+                "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.data),
+                "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                "title": "Cache collections",
+            }]
         }
-        data['links'].append({
-            "href": self.href(context, "/collections"),
-            "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.data),
-            "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
-            "title": "Cache collections",
-        })
-
-        html_metadata = {
-            "pageTitle": self.linkTitle(),
-            "navigation": []
-        }
-
-        self.write(data, context, html_metadata)
-
-    def templatePath(self, context):
-        # No templates!
-        return ''
-
-    def parameters(self, context):
-        return []
+        self.write(data)
 
 
-class CacheMngrCollectionsHandler(CacheMngrApiHandler):
-    """Project listing handler"""
+class Collections(RequestHandler):
+    """ Project listing handler
+    """
+    def get(self) -> None:
+        """ List projects
+        """
+        metadata, coll = read_metadata_collection(self.rootdir)
 
-    def path(self):
-        return QRegularExpression(r"/collections(\.json|\.html|/)")
-
-    def operationId(self):
-        return "describeCollections"
-
-    def summary(self):
-        return "WMTS Cache Collections (Projects)"
-
-    def description(self):
-        return "WMTS Cache Collections (Projects)"
-
-    def linkTitle(self):
-        return "WMTS Cache Collections (Projects)"
-
-    def linkType(self):
-        return QgsServerOgcApi.items
-
-    def handleRequest(self, context):
-        """List projects"""
-
-        metadata = read_metadata(self.rootdir)
+        def links():
+            for name,project in coll:
+                yield { 'id': name,
+                        'project': project,
+                        'links': [{
+                            "href": self.href(f"/{name})", QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                            "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
+                            "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                            "title": "Cache collection",
+                        }]}
 
         data = {
             "cache_layout": metadata['layout'],
-            "collections": [],
-            "links": []  # self.links(context),
+            "collections": list(links()),
+            "links": [],  # self.links(context)
         }
 
-        for h, v in metadata['data'].items():
-            data['collections'].append({
-                'id': h,
-                'project': v['project'],
-                'links': [{
-                    "href": self.href(context, "/{}".format(h), QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+        self.write(data)
+
+
+class MetadataMixIn:
+
+    def get_metadata(self, collectionid: str):
+        """ Return project metadata 
+        """
+        try:
+            project, layers = read_project_metadata(self.rootdir, collectionid)
+        except FileNotFoundError:
+            raise HTTPError(404,reason=f"Collection '{collectionid}' not found") from None
+
+        metadata = read_wmts_metadata(self.rootdir)
+        return metadata, project, layers
+
+    def cache_helper(self, metadata):
+        """ Return cache helper
+        """
+        return CacheHelper(self.rootdir, metadata['layout'])
+
+
+class ProjectCollection(RequestHandler,MetadataMixIn):
+    """ Project listing handler
+    """
+
+    def get(self, collectionid: str):
+        """ Return project metadata 
+        """
+        metadata, project, layers = self.get_metadata(collectionid)
+
+        def links():
+            for layer in layers:
+                yield { 'id': layer,
+                        'links': [{ 
+                            'href': self.href(f"/layers/{layer})", \
+                                              QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                            'rel': QgsServerOgcApi.relToString(QgsServerOgcApi.item),
+                            'type': QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                            'title': "Cache layer",
+                        }]}
+
+        data = {
+            'id': collectionid,
+            'project': project,
+            'layers' : list(links()),
+            'links'  : [
+                {
+                    "href": self.href("/docs", QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
                     "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
                     "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
-                    "title": "Cache collection",
-                }]
-            })
+                    "title": "Cache collection documents",
+                },
+                {
+                    "href": self.href("/layers", QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                    "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
+                    "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                    "title": "Cache collection layers",
+                },                
+            ],
+        } 
 
-        html_metadata = {
-            "pageTitle": self.linkTitle(),
-            "navigation": [{
-                'title': 'Landing page',
-                'href': self.parentLink(context.request().url(), 1)
-            }]
+        self.write(data)
+
+    def delete(self, collectionid) -> None:
+        """ Clear cache
+        """
+        metadata,project,_ = self.get_metadata(collectionid)
+        cache = self.cache_helper(metadata)
+
+        # Remove docs
+        docroot = cache.get_documents_root(project)
+        if docroot.exists():
+            rmtree(docroot.as_posix())
+            # Remove tiles
+        tileroot = cache.get_tiles_root(project)
+        if tileroot.exists():
+            rmtree(tileroot.as_posix())
+        # Remove medatata infos
+        inf = (self.rootdir / collectionid).with_suffix('.inf')
+        if inf.exists():
+            inf.unlink()
+
+
+class DocumentCollection(RequestHandler,MetadataMixIn):
+    """ Return documentation about project 
+    """
+
+    def get(self, collectionid):
+        """ Get documents count
+        """
+        metadata,project,_ = self.get_metadata(collectionid)
+        cache = self.cache_helper(metadata)
+
+        docroot = cache.get_documents_root(project)
+        data = {
+            'id': collectionid,
+            'project': project,
+            'documents': sum( 1 for _ in docroot.glob('*.xml')),
+            'links': [], # self.links(context)
         }
 
-        self.write(data, context, html_metadata)
-
-    def templatePath(self, context):
-        # No templates!
-        return ''
-
-    def parameters(self, context):
-        return []
+        self.write(data)
 
 
-class CacheMngrCollectionHandler(CacheMngrApiHandler):
-    """Project listing handler"""
+    def delete(self, collectionid ) -> None:
+        """ Delete item from cache
+        """
+        metadata,project,_ = self.get_metadata(collectionid)
+        cache = self.cache_helper(metadata)
 
-    def path(self):
-        return QRegularExpression(r"/collections/(?<collectionId>[^/]+?)(\.json|\.html|/)")
+        docroot = cache.get_documents_root(project)
+        if docroot.exists():
+            rmtree(docroot.as_posix())
 
-    def operationId(self):
-        return "describeCollection"
 
-    def summary(self):
-        return "WMTS Cache Collection (Project)"
+class LayerCollection(RequestHandler,MetadataMixIn):
+    """ 
+    """
 
-    def description(self):
-        return "WMTS Cache Collection (Project)"
+    def get(self, collectionid):
+        """ Layer info
+        """
+        metadata,project,layers = self.get_metadata(collectionid)
 
-    def linkTitle(self):
-        return "WMTS Cache Collection (Project)"
-
-    def linkType(self):
-        return QgsServerOgcApi.items
-
-    def handleRequest(self, context):
-        """List projects"""
-
-        match = self.path().match(context.request().url().path())
-        if not match.hasMatch():
-            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
-            return
-
-        collection_id = match.captured('collectionId')
-
-        metadata = read_metadata(self.rootdir)
-
-        if collection_id not in metadata['data']:
-            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
-            return
-
-        collection_data = {h: v for h, v in metadata['data'].items() if h == collection_id}
-
-        if context.request().method() == QgsServerRequest.DeleteMethod:
-            cache = CacheHelper(self.rootdir, metadata['layout'])
-            for h, v in collection_data.items():
-                project = v['project']
-                # Remove docs
-                docroot = cache.get_documents_root(project)
-                if docroot.exists():
-                    rmtree(docroot.as_posix())
-                # Remove tiles
-                tileroot = cache.get_tiles_root(project)
-                if tileroot.exists():
-                    rmtree(tileroot.as_posix())
-                # Remove medatata infos
-                cachedir = self.rootdir / h
-                inf = cachedir.with_suffix('.inf')
-                if inf.exists():
-                    inf.unlink()
-                self.write({}, context)
-        else:
-            data = {
-            }
-            for h, v in collection_data.items():
-                data['id'] = h
-                data['project'] = v['project']
-                data['layers'] = []
-                for layer in v['layers']:
-                    data['layers'].append({
-                        'id': layer,
+        def links():
+            for layer in layers:
+                yield { 'id': layer,
                         'links': [{
-                            "href": self.href(
-                                context,
-                                "/layers/{}".format(layer),
-                                QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)
-                            ),
-                            "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
-                            "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
-                            "title": "Cache layer",
-                        }]
-                    })
-            data['links'] = []  # self.links(context)
-            data['links'].append({
-                "href": self.href(context, "/docs", QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
-                "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
-                "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
-                "title": "Cache collection documents",
-            })
-            data['links'].append({
-                "href": self.href(context, "/layers", QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
-                "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
-                "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
-                "title": "Cache collection layers",
-            })
+                            'href': self.href(f"/layers/{layer})", \
+                                              QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                            'rel': QgsServerOgcApi.relToString(QgsServerOgcApi.item),
+                            'type': QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                            'title': "Cache layer",
+                        }]}
 
-            html_metadata = {
-                "pageTitle": self.linkTitle(),
-                "navigation": [{
-                    'title': 'Landing page',
-                    'href': self.parentLink(context.request().url(), 2)
-                }, {
-                    'title': 'Collections',
-                    'href': self.parentLink(context.request().url(), 1)
-                }]
-            }
+        data = {
+            'id': collectionid,
+            'project': project,
+            'layers' : list(links()),
+            'links'  : [], # self.links(context)
+        }
 
-            self.write(data, context, html_metadata)
+        self.write(data)
 
-    def templatePath(self, context):
-        # No templates!
-        return ''
+    def delete(self, collectionid) -> None:
+        """  Delete layer tiles
+        """
+        metadata,project,_ = self.get_metadata(collectionid)
+        cache = self.cache_helper(metadata)
 
-    def parameters(self, context):
-        return []
+        # Remove tiles
+        tileroot = cache.get_tiles_root(project)
+        if tileroot.exists():
+            rmtree(tileroot.as_posix())
 
 
-class CacheMngrCollectionDocsHandler(CacheMngrApiHandler):
-    """Project listing handler"""
+class LayerCache(RequestHandler,MetadataMixIn):
+    """ Handle cached layer
+    """
 
-    def path(self):
-        return QRegularExpression(r"/collections/(?<collectionId>[^/]+?)/docs(\.json|\.html|/)")
+    def get( self, collectionid: str, layerid: str) -> None:
+        """ 
+        """
+        metadata, project, layers = self.get_metadata(collectionid)
+        if layerid not in layers:
+            raise HTTPError(404,reason=f"Layer '{layerid}' not found")
+       
+        data = {
+            'id': layerid,
+            'links':[],
+        }
+        self.write(data)
 
-    def operationId(self):
-        return "describeDocs"
+    
+    def delete( self, collectionid: str, layerid: str) -> None:
+        """ List projects
+        """
+        metadata, project, layers = self.get_metadata(collectionid)
+        if layerid not in layers:
+            raise HTTPError(404,reason=f"Layer '{layerid}' not found")
 
-    def summary(self):
-        return "WMTS Cache Collection (Project) Documents"
-
-    def description(self):
-        return "WMTS Cache Collection (Project) Documents"
-
-    def linkTitle(self):
-        return "WMTS Cache Collection (Project) Documents"
-
-    def linkType(self):
-        return QgsServerOgcApi.items
-
-    def handleRequest(self, context):
-        """List projects"""
-
-        match = self.path().match(context.request().url().path())
-        if not match.hasMatch():
-            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
-            return
-
-        collection_id = match.captured('collectionId')
-
-        metadata = read_metadata(self.rootdir)
-
-        if collection_id not in metadata['data']:
-            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
-            return
-
-        collection_data = {h: v for h, v in metadata['data'].items() if h == collection_id}
-
+        cache = self.cache_helper(metadata)   
         cache = CacheHelper(self.rootdir, metadata['layout'])
 
-        data = {}
-        for h, v in collection_data.items():
-            project = v['project']
-            if context.request().method() == QgsServerRequest.DeleteMethod:
-                # Remove docs
-                docroot = cache.get_documents_root(project)
-                if docroot.exists():
-                    rmtree(docroot.as_posix())
-                self.write(data, context)
-            else:
-
-                data['id'] = h
-                data['project'] = project
-                data['documents'] = 0
-                data['links'] = []  # self.links(context)
-
-                docroot = cache.get_documents_root(project)
-                for _ in docroot.glob('*.xml'):
-                    data['documents'] += 1
-
-                html_metadata = {
-                    "pageTitle": self.linkTitle(),
-                    "navigation": [{
-                        'title': 'Landing page',
-                        'href': self.parentLink(context.request().url(), 3)
-                    }, {
-                        'title': 'Collections',
-                        'href': self.parentLink(context.request().url(), 2)
-                    }, {
-                        'title': 'Collection',
-                        'href': self.parentLink(context.request().url(), 1)
-                    }]
-                }
-
-                self.write(data, context, html_metadata)
-
-    def templatePath(self, context):
-        # No templates!
-        return ''
-
-    def parameters(self, context):
-        return []
+        # Remove tiles
+        cachedir = cache.get_tiles_root(project) / layerid
+        if cachedir.exists():
+            rmtree(cachedir.as_posix())
 
 
-class CacheMngrCollectionLayersHandler(CacheMngrApiHandler):
-    """Project listing handler"""
+def init_cache_api(serverIface, cacherootdir: Path) -> None:
+    """ Initialize the cache manager API
+    """
+    collectionid = r"collections/(?P<collectionid>[^/]+)"
 
-    def path(self):
-        return QRegularExpression(r"/collections/(?<collectionId>[^/]+?)/layers(\.json|\.html|/)")
+    kwargs = dict(rootdir=cacherootdir)
 
-    def operationId(self):
-        return "describeLayers"
+    handlers = [
+        (rf"/{collectionid}/layers/(?P<layerid>[^/]+)/?", LayerCache, kwargs),
+        (rf"/{collectionid}/layers/?", LayerCollection, kwargs),
+        (rf"/{collectionid}/docs/?", DocumentCollection, kwargs),
+        (rf"/{collectionid}/?", ProjectCollection,  kwargs),
+        (rf"/collections/?", Collections, kwargs),
+        (rf"/?", LandingPage, kwargs),
+    ]
 
-    def summary(self):
-        return "WMTS Cache Collection (Project) layers"
-
-    def description(self):
-        return "WMTS Cache Collection (Project) layers"
-
-    def linkTitle(self):
-        return "WMTS Cache Collection (Project) layers"
-
-    def linkType(self):
-        return QgsServerOgcApi.items
-
-    def handleRequest(self, context):
-        """List projects"""
-
-        match = self.path().match(context.request().url().path())
-        if not match.hasMatch():
-            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
-            return
-
-        collection_id = match.captured('collectionId')
-
-        metadata = read_metadata(self.rootdir)
-
-        if collection_id not in metadata['data']:
-            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
-            return
-
-        collection_data = {h: v for h, v in metadata['data'].items() if h == collection_id}
-
-        cache = CacheHelper(self.rootdir, metadata['layout'])
-
-        data = {}
-        for h, v in collection_data.items():
-            if context.request().method() == QgsServerRequest.DeleteMethod:
-                project = v['project']
-                # Remove tiles
-                tileroot = cache.get_tiles_root(project)
-                if tileroot.exists():
-                    rmtree(tileroot.as_posix())
-                self.write(data, context)
-            else:
-                data['id'] = h
-                data['project'] = v['project']
-                data['layers'] = []
-                for layer in v['layers']:
-                    data['layers'].append({
-                        'id': layer,
-                        'links': [{
-                            "href": self.href(
-                                context,
-                                "/layers/{}".format(layer),
-                                QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)
-                            ),
-                            "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
-                            "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
-                            "title": "Cache layer",
-                        }]
-                    })
-                data['links'] = []  # self.links(context)
-
-                html_metadata = {
-                    "pageTitle": self.linkTitle(),
-                    "navigation": [{
-                        'title': 'Landing page',
-                        'href': self.parentLink(context.request().url(), 3)
-                    }, {
-                        'title': 'Collections',
-                        'href': self.parentLink(context.request().url(), 2)
-                    }, {
-                        'title': 'Collection',
-                        'href': self.parentLink(context.request().url(), 1)
-                    }]
-                }
-
-                self.write(data, context, html_metadata)
-
-    def templatePath(self, context):
-        # No templates!
-        return ''
-
-    def parameters(self, context):
-        return []
+    register_api_handlers(serverIface, '/wmtscache', 'CacheManagment', handlers)
 
 
-class CacheMngrCollectionLayerHandler(CacheMngrApiHandler):
-    """Project listing handler"""
-
-    def path(self):
-        return QRegularExpression(r"/collections/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?)(\.json|\.html|/)")
-
-    def operationId(self):
-        return "describeLayer"
-
-    def summary(self):
-        return "WMTS Cache Collection (Project) layer"
-
-    def description(self):
-        return "WMTS Cache Collection (Project) layer"
-
-    def linkTitle(self):
-        return "WMTS Cache Collection (Project) layer"
-
-    def linkType(self):
-        return QgsServerOgcApi.items
-
-    def handleRequest(self, context):
-        """List projects"""
-
-        match = self.path().match(context.request().url().path())
-        if not match.hasMatch():
-            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
-            return
-
-        collection_id = match.captured('collectionId')
-
-        metadata = read_metadata(self.rootdir)
-
-        if collection_id not in metadata['data']:
-            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
-            return
-
-        collection_data = {h: v for h, v in metadata['data'].items() if h == collection_id}
-
-        layer_id = match.captured('layerId')
-
-        cache = CacheHelper(self.rootdir, metadata['layout'])
-
-        data = {}
-        for _, v in collection_data.items():
-            if layer_id not in v['layers']:
-                self.sendException(QgsServerApiNotFoundError("Layer was not found"), context)
-                return
-
-            if context.request().method() == QgsServerRequest.DeleteMethod:
-                project = v['project']
-                # Remove tiles
-                tileroot = cache.get_tiles_root(project)
-                cachedir = tileroot / layer_id
-                if cachedir.exists():
-                    rmtree(cachedir.as_posix())
-                self.write(data, context)
-            else:
-                data['id'] = layer_id
-                data['links'] = []  # self.links(context)
-
-                html_metadata = {
-                    "pageTitle": self.linkTitle(),
-                    "navigation": [{
-                        'title': 'Landing page',
-                        'href': self.parentLink(context.request().url(), 4)
-                    }, {
-                        'title': 'Collections',
-                        'href': self.parentLink(context.request().url(), 3)
-                    }, {
-                        'title': 'Collection',
-                        'href': self.parentLink(context.request().url(), 2)
-                    }, {
-                        'title': 'Layers',
-                        'href': self.parentLink(context.request().url(), 1)
-                    }]
-                }
-
-                self.write(data, context, html_metadata)
-
-    def templatePath(self, context):
-        # No templates!
-        return ''
-
-    def parameters(self, context):
-        return []
-
-
-class CacheMngrApi(QgsServerOgcApi):
-
-    def __init__(self, serverIface, rootpath):
-        super().__init__(serverIface, '/cachemngr',
-                         'cache manager api', 'a cache manager api',
-                         '1.0')
-        self.registerHandler(CacheMngrCollectionLayerHandler(rootpath))
-        self.registerHandler(CacheMngrCollectionLayersHandler(rootpath))
-        self.registerHandler(CacheMngrCollectionDocsHandler(rootpath))
-        self.registerHandler(CacheMngrCollectionHandler(rootpath))
-        self.registerHandler(CacheMngrCollectionsHandler(rootpath))
-        self.registerHandler(CacheMngrLandingPageHandler(rootpath))
-        self.rootpath = rootpath

--- a/wmtsCacheServer/cachemngrapi.py
+++ b/wmtsCacheServer/cachemngrapi.py
@@ -1,0 +1,584 @@
+import json
+
+from pathlib import Path
+from shutil import rmtree
+
+from qgis.PyQt.QtCore import (
+    QRegularExpression,
+)
+
+from qgis.server import (
+    QgsServerException,
+    QgsServerOgcApiHandler,
+    QgsServerOgcApi,
+    QgsServerRequest,
+)
+
+from .helper import CacheHelper
+
+def read_metadata(rootdir: Path) -> dict:
+    """ Read metadata
+    """
+
+    metadata = rootdir / 'wmts.json'
+    if not metadata.exists():
+        raise Exception('Cannot read cache metadata!')
+
+    metadata = json.loads(metadata.read_text())
+
+    data = {}
+    for c in rootdir.glob('*.inf'):
+        d = c.with_suffix('')
+        h = d.name
+
+        tiledir = d / 'tiles'
+        layers = [l.name for l in tiledir.glob('*') if l.is_dir()]
+
+        data[h] = {
+           'project': c.read_text(),
+           'layers': layers,
+        }
+    #metadata.update(data=data)
+    metadata['data'] = data
+    return metadata
+
+
+class QgsServerApiException():
+
+    def __init__(self, code, message, mime_type = 'application/json', response_code = 200):
+        self.code = code
+        self.message = message
+        self.mime_type = mime_type
+        self.response_code = response_code
+
+    def formatResponse(self):
+        return json.dumps({
+            'code': self.code,
+            'description': self.what()
+        }), self.mime_type
+
+    def responseCode(self):
+        return self.response_code
+
+    def what(self):
+        return self.message
+
+
+class QgsServerApiNotFoundError(QgsServerApiException):
+
+    def __init__(self, message, mime_type = 'application/json', response_code = 404):
+        super().__init__('API not found error', message, mime_type, response_code)
+
+
+class CacheMngrApiHandler(QgsServerOgcApiHandler):
+
+    def __init__(self, rootdir):
+        super().__init__()
+        self.setContentTypes([QgsServerOgcApi.JSON, QgsServerOgcApi.HTML])
+
+        self.rootdir = rootdir
+
+    def sendException(self, ex, context):
+        resp_content, mime_type = ex.formatResponse()
+        resp = context.response()
+        resp.clear()
+        resp.setStatusCode(ex.responseCode());
+        resp.setHeader("Content-Type", mime_type)
+        resp.write(resp_content)
+
+
+class CacheMngrLandingPageHandler(CacheMngrApiHandler):
+    """Project listing handler"""
+
+    def path(self):
+        return QRegularExpression("(\.json|\.html|/)")
+
+    def operationId(self):
+        return "getLandingPage"
+
+    def summary(self):
+        return "WMTS Cache Manager landing page"
+
+    def description(self):
+        return "WMTS Cache Manager landing page"
+
+    def linkTitle(self):
+        return "WMTS Cache Manager landing page"
+
+    def linkType(self):
+        return QgsServerOgcApi.items
+
+    def handleRequest(self, context):
+        """List projects"""
+
+        data = {
+            "links": [] #self.links(context)
+        }
+        data['links'].append({
+            "href": self.href(context, "/collections"),
+            "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.data),
+            "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+            "title": "Cache collections",
+        })
+
+        html_metadata = {
+            "pageTitle": self.linkTitle(),
+            "navigation": []
+        }
+
+        self.write(data, context, html_metadata)
+
+    def templatePath(self, context):
+        # No templates!
+        return ''
+
+    def parameters(self, context):
+        return []
+
+
+class CacheMngrCollectionsHandler(CacheMngrApiHandler):
+    """Project listing handler"""
+
+    def path(self):
+        return QRegularExpression("/collections(\.json|\.html|/)")
+
+    def operationId(self):
+        return "describeCollections"
+
+    def summary(self):
+        return "WMTS Cache Collections (Projects)"
+
+    def description(self):
+        return "WMTS Cache Collections (Projects)"
+
+    def linkTitle(self):
+        return "WMTS Cache Collections (Projects)"
+
+    def linkType(self):
+        return QgsServerOgcApi.items
+
+    def handleRequest(self, context):
+        """List projects"""
+
+        metadata = read_metadata(self.rootdir)
+
+        data = {
+            "cache_layout": metadata['layout'],
+            "collections": [],
+            "links": [] #self.links(context),
+        }
+
+        for h, v in metadata['data'].items():
+            data['collections'].append({
+                'id': h,
+                'project': v['project'],
+                'links': [{
+                    "href": self.href(context, "/{}".format(h), QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                    "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
+                    "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                    "title": "Cache collection",
+                }]
+            })
+
+        html_metadata = {
+            "pageTitle": self.linkTitle(),
+            "navigation": [{
+                'title': 'Landing page',
+                'href': self.parentLink(context.request().url(), 1)
+            }]
+        }
+
+        self.write(data, context, html_metadata)
+
+    def templatePath(self, context):
+        # No templates!
+        return ''
+
+    def parameters(self, context):
+        return []
+
+
+class CacheMngrCollectionHandler(CacheMngrApiHandler):
+    """Project listing handler"""
+
+    def path(self):
+        return QRegularExpression("/collections/(?<collectionId>[^/]+?)(\.json|\.html|/)")
+
+    def operationId(self):
+        return "describeCollection"
+
+    def summary(self):
+        return "WMTS Cache Collection (Project)"
+
+    def description(self):
+        return "WMTS Cache Collection (Project)"
+
+    def linkTitle(self):
+        return "WMTS Cache Collection (Project)"
+
+    def linkType(self):
+        return QgsServerOgcApi.items
+
+    def handleRequest(self, context):
+        """List projects"""
+
+        match = self.path().match(context.request().url().path())
+        if not match.hasMatch():
+            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
+            return
+
+        collection_id = match.captured('collectionId')
+
+        metadata = read_metadata(self.rootdir)
+
+        if collection_id not in metadata['data']:
+            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
+            return
+
+        collection_data = {h: v for h, v in metadata['data'].items() if h == collection_id}
+
+        if context.request().method() == QgsServerRequest.DeleteMethod:
+            cache = CacheHelper(self.rootdir, metadata['layout'])
+            for h, v in collection_data.items():
+                project = v['project']
+                # Remove docs
+                docroot = cache.get_documents_root(project)
+                if docroot.exists():
+                    rmtree(docroot.as_posix())
+                # Remove tiles
+                tileroot = cache.get_tiles_root(project)
+                if tileroot.exists():
+                    rmtree(tileroot.as_posix())
+                # Remove medatata infos
+                cachedir = self.rootdir / h
+                inf = cachedir.with_suffix('.inf')
+                if inf.exists():
+                    inf.unlink()
+                self.write({}, context)
+        else:
+            data = {
+            }
+            for h, v in collection_data.items():
+                data['id'] = h
+                data['project'] = v['project']
+                data['layers'] = []
+                for layer in v['layers']:
+                    data['layers'].append({
+                        'id': layer,
+                        'links': [{
+                            "href": self.href(context, "/layers/{}".format(layer), QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                            "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
+                            "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                            "title": "Cache layer",
+                        }]
+                    })
+            data['links'] = [] #self.links(context)
+            data['links'].append({
+                "href": self.href(context, "/docs", QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
+                "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                "title": "Cache collection documents",
+            })
+            data['links'].append({
+                "href": self.href(context, "/layers", QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
+                "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                "title": "Cache collection layers",
+            })
+
+            html_metadata = {
+                "pageTitle": self.linkTitle(),
+                "navigation": [{
+                    'title': 'Landing page',
+                    'href': self.parentLink(context.request().url(), 2)
+                }, {
+                    'title': 'Collections',
+                    'href': self.parentLink(context.request().url(), 1)
+                }]
+            }
+
+            self.write(data, context, html_metadata)
+
+    def templatePath(self, context):
+        # No templates!
+        return ''
+
+    def parameters(self, context):
+        return []
+
+
+class CacheMngrCollectionDocsHandler(CacheMngrApiHandler):
+    """Project listing handler"""
+
+    def path(self):
+        return QRegularExpression("/collections/(?<collectionId>[^/]+?)/docs(\.json|\.html|/)")
+
+    def operationId(self):
+        return "describeDocs"
+
+    def summary(self):
+        return "WMTS Cache Collection (Project) Documents"
+
+    def description(self):
+        return "WMTS Cache Collection (Project) Documents"
+
+    def linkTitle(self):
+        return "WMTS Cache Collection (Project) Documents"
+
+    def linkType(self):
+        return QgsServerOgcApi.items
+
+    def handleRequest(self, context):
+        """List projects"""
+
+        match = self.path().match(context.request().url().path())
+        if not match.hasMatch():
+            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
+            return
+
+        collection_id = match.captured('collectionId')
+
+        metadata = read_metadata(self.rootdir)
+
+        if collection_id not in metadata['data']:
+            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
+            return
+
+        collection_data = {h: v for h, v in metadata['data'].items() if h == collection_id}
+
+        cache = CacheHelper(self.rootdir, metadata['layout'])
+
+        data = {}
+        for h, v in collection_data.items():
+            project = v['project']
+            if context.request().method() == QgsServerRequest.DeleteMethod:
+                # Remove docs
+                docroot = cache.get_documents_root(project)
+                if docroot.exists():
+                    rmtree(docroot.as_posix())
+                self.write(data, context)
+            else:
+
+                data['id'] = h
+                data['project'] = project
+                data['documents'] = 0
+                data['links'] = [] #self.links(context)
+
+                docroot = cache.get_documents_root(project)
+                for _ in docroot.glob('*.xml'):
+                    data['documents'] += 1
+
+                html_metadata = {
+                    "pageTitle": self.linkTitle(),
+                    "navigation": [{
+                        'title': 'Landing page',
+                        'href': self.parentLink(context.request().url(), 3)
+                    }, {
+                        'title': 'Collections',
+                        'href': self.parentLink(context.request().url(), 2)
+                    }, {
+                        'title': 'Collection',
+                        'href': self.parentLink(context.request().url(), 1)
+                    }]
+                }
+
+                self.write(data, context, html_metadata)
+
+    def templatePath(self, context):
+        # No templates!
+        return ''
+
+    def parameters(self, context):
+        return []
+
+
+class CacheMngrCollectionLayersHandler(CacheMngrApiHandler):
+    """Project listing handler"""
+
+    def path(self):
+        return QRegularExpression("/collections/(?<collectionId>[^/]+?)/layers(\.json|\.html|/)")
+
+    def operationId(self):
+        return "describeLayers"
+
+    def summary(self):
+        return "WMTS Cache Collection (Project) layers"
+
+    def description(self):
+        return "WMTS Cache Collection (Project) layers"
+
+    def linkTitle(self):
+        return "WMTS Cache Collection (Project) layers"
+
+    def linkType(self):
+        return QgsServerOgcApi.items
+
+    def handleRequest(self, context):
+        """List projects"""
+
+        match = self.path().match(context.request().url().path())
+        if not match.hasMatch():
+            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
+            return
+
+        collection_id = match.captured('collectionId')
+
+        metadata = read_metadata(self.rootdir)
+
+        if collection_id not in metadata['data']:
+            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
+            return
+
+        collection_data = {h: v for h, v in metadata['data'].items() if h == collection_id}
+
+        cache = CacheHelper(self.rootdir, metadata['layout'])
+
+        data = {}
+        for h, v in collection_data.items():
+            if context.request().method() == QgsServerRequest.DeleteMethod:
+                project = v['project']
+                # Remove tiles
+                tileroot = cache.get_tiles_root(project)
+                if tileroot.exists():
+                    rmtree(tileroot.as_posix())
+                self.write(data, context)
+            else:
+                data['id'] = h
+                data['project'] = v['project']
+                data['layers'] = []
+                for layer in v['layers']:
+                    data['layers'].append({
+                        'id': layer,
+                        'links': [{
+                            "href": self.href(context, "/layers/{}".format(layer), QgsServerOgcApi.contentTypeToExtension(QgsServerOgcApi.JSON)),
+                            "rel": QgsServerOgcApi.relToString(QgsServerOgcApi.item),
+                            "type": QgsServerOgcApi.mimeType(QgsServerOgcApi.JSON),
+                            "title": "Cache layer",
+                        }]
+                    })
+                data['links'] = [] #self.links(context)
+
+                html_metadata = {
+                    "pageTitle": self.linkTitle(),
+                    "navigation": [{
+                        'title': 'Landing page',
+                        'href': self.parentLink(context.request().url(), 3)
+                    }, {
+                        'title': 'Collections',
+                        'href': self.parentLink(context.request().url(), 2)
+                    }, {
+                        'title': 'Collection',
+                        'href': self.parentLink(context.request().url(), 1)
+                    }]
+                }
+
+                self.write(data, context, html_metadata)
+
+    def templatePath(self, context):
+        # No templates!
+        return ''
+
+    def parameters(self, context):
+        return []
+
+
+class CacheMngrCollectionLayerHandler(CacheMngrApiHandler):
+    """Project listing handler"""
+
+    def path(self):
+        return QRegularExpression("/collections/(?<collectionId>[^/]+?)/layers/(?<layerId>[^/]+?)(\.json|\.html|/)")
+
+    def operationId(self):
+        return "describeLayer"
+
+    def summary(self):
+        return "WMTS Cache Collection (Project) layer"
+
+    def description(self):
+        return "WMTS Cache Collection (Project) layer"
+
+    def linkTitle(self):
+        return "WMTS Cache Collection (Project) layer"
+
+    def linkType(self):
+        return QgsServerOgcApi.items
+
+    def handleRequest(self, context):
+        """List projects"""
+
+        match = self.path().match(context.request().url().path())
+        if not match.hasMatch():
+            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
+            return
+
+        collection_id = match.captured('collectionId')
+
+        metadata = read_metadata(self.rootdir)
+
+        if collection_id not in metadata['data']:
+            self.sendException(QgsServerApiNotFoundError("Collection was not found"), context)
+            return
+
+        collection_data = {h: v for h, v in metadata['data'].items() if h == collection_id}
+
+        layer_id = match.captured('layerId')
+
+        cache = CacheHelper(self.rootdir, metadata['layout'])
+
+        data = {}
+        for _, v in collection_data.items():
+            if layer_id not in v['layers']:
+                self.sendException(QgsServerApiNotFoundError("Layer was not found"), context)
+                return
+
+            if context.request().method() == QgsServerRequest.DeleteMethod:
+                project = v['project']
+                # Remove tiles
+                tileroot = cache.get_tiles_root(project)
+                cachedir = tileroot / layer_id
+                if cachedir.exists():
+                    rmtree(cachedir.as_posix())
+                self.write(data, context)
+            else:
+                data['id'] = layer_id
+                data['links'] = [] #self.links(context)
+
+                html_metadata = {
+                    "pageTitle": self.linkTitle(),
+                    "navigation": [{
+                        'title': 'Landing page',
+                        'href': self.parentLink(context.request().url(), 4)
+                    }, {
+                        'title': 'Collections',
+                        'href': self.parentLink(context.request().url(), 3)
+                    }, {
+                        'title': 'Collection',
+                        'href': self.parentLink(context.request().url(), 2)
+                    }, {
+                        'title': 'Layers',
+                        'href': self.parentLink(context.request().url(), 1)
+                    }]
+                }
+
+                self.write(data, context, html_metadata)
+
+    def templatePath(self, context):
+        # No templates!
+        return ''
+
+    def parameters(self, context):
+        return []
+
+class CacheMngrApi(QgsServerOgcApi):
+
+    def __init__(self, serverIface, rootpath):
+        super().__init__(serverIface, '/cachemngr',
+                         'cache manager api', 'a cache manager api',
+                         '1.0')
+        self.registerHandler(CacheMngrCollectionLayerHandler(rootpath))
+        self.registerHandler(CacheMngrCollectionLayersHandler(rootpath))
+        self.registerHandler(CacheMngrCollectionDocsHandler(rootpath))
+        self.registerHandler(CacheMngrCollectionHandler(rootpath))
+        self.registerHandler(CacheMngrCollectionsHandler(rootpath))
+        self.registerHandler(CacheMngrLandingPageHandler(rootpath))
+        self.rootpath = rootpath

--- a/wmtsCacheServer/helper.py
+++ b/wmtsCacheServer/helper.py
@@ -40,9 +40,7 @@ class CacheHelper:
             raise ValueError("Unknown tile layout %s" % layout)
 
         metadata = rootdir / 'wmts.json'
-        metadata.write_text(json.dumps({
-                'layout': layout,
-        }))
+        metadata.write_text(json.dumps({'layout': layout,}))
 
     def get_project_hash(self, ident: str) -> Hash:
         """ Attempt to create a hash from project infos

--- a/wmtsCacheServer/layouts.py
+++ b/wmtsCacheServer/layouts.py
@@ -34,9 +34,9 @@ def tile_location_tc(root: Path, x: int, y: int, z: Union[int,str], file_ext: st
         scheme: zz/xxx/xxx/xxx/yyy/yyy/yyy.format
     """
     try:
-      level = "%02d" % int(z)
+        level = "%02d" % int(z)
     except ValueError:
-      level = z
+        level = z
 
     parts = (
         level,
@@ -57,9 +57,9 @@ def tile_location_mp(root: Path, x: int, y: int, z: Union[int,str], file_ext: st
         scheme: zz/xxxx/xxxx/yyyy/yyyy.format
     """
     try:
-      level = "%02d" % int(z)
+        level = "%02d" % int(z)
     except ValueError:
-      level = z
+        level = z
 
     parts = (
         level,

--- a/wmtsCacheServer/metadata.txt
+++ b/wmtsCacheServer/metadata.txt
@@ -1,7 +1,7 @@
 [general]
 name=wmtsCacheServer
 version=master
-qgisMinimumVersion=3.4
+qgisMinimumVersion=3.10
 description=WMTS caching mechanism on disk for QGIS Server
 about=WMTS caching mechanism on disk for QGIS Server
 author=3Liz

--- a/wmtsCacheServer/wmtsCacheServer.py
+++ b/wmtsCacheServer/wmtsCacheServer.py
@@ -13,7 +13,7 @@ from qgis.core import Qgis, QgsMessageLog
 from qgis.server import QgsServerInterface
 
 from .cachefilter import DiskCacheFilter
-from .cachemngrapi import CacheMngrApi
+from .cachemngrapi import init_cache_api
 
 
 class wmtsCacheServer:
@@ -45,10 +45,10 @@ class wmtsCacheServer:
                                          debug=debug_headers), 50 )
 
         # Cache Manager API
-        api = CacheMngrApi(serverIface, self.rootpath)
-        serverIface.serviceRegistry().registerApi(api)
+        init_cache_api(serverIface, self.rootpath)
 
     def create_filter(self, layout: str=None) -> DiskCacheFilter:
         """ Create a new filter instance
         """
         return DiskCacheFilter(self.serverIface, self.rootpath, layout or 'tc')
+

--- a/wmtsCacheServer/wmtsCacheServer.py
+++ b/wmtsCacheServer/wmtsCacheServer.py
@@ -13,6 +13,7 @@ from qgis.core import Qgis, QgsMessageLog
 from qgis.server import QgsServerInterface
 
 from .cachefilter import DiskCacheFilter
+from .cachemngrapi import CacheMngrApi
 
 
 class wmtsCacheServer:
@@ -42,6 +43,10 @@ class wmtsCacheServer:
 
         serverIface.registerServerCache( DiskCacheFilter(serverIface, self.rootpath, layout,
                                          debug=debug_headers), 50 )
+
+        # Cache Manager API
+        api = CacheMngrApi(serverIface, self.rootpath)
+        serverIface.serviceRegistry().registerApi(api)
 
     def create_filter(self, layout: str=None) -> DiskCacheFilter:
         """ Create a new filter instance


### PR DESCRIPTION
Refactorize API:

* Use delegate handler for handling http methods as separate call, enforce 405 on invalid method
* Remove `.json` suffixes from urls
* Modify tests accordingly to changes.
* Use lazy generators when fetching metadata
