### PR TITLE
RequestHandlerDelegate.contentTypes and RequestHandler.links

### DIFF
--- a/tests/test_wmts_cachemngrapi.py
+++ b/tests/test_wmts_cachemngrapi.py
@@ -33,8 +33,11 @@ def test_wmts_cachemngrapi_empty_cache(client):
 
     json_content = json.loads(rv.content)
     assert 'links' in json_content
-    assert len(json_content['links']) == 1
-    assert json_content['links'][0]['title'] == 'Cache collections'
+    assert len(json_content['links']) == 2
+    assert json_content['links'][0]['title'] == 'WMTS Cache manager LandingPage as JSON'
+    assert json_content['links'][0]['rel'] == 'self'
+    assert json_content['links'][1]['title'] == 'WMTS Cache manager Collections as JSON'
+    assert json_content['links'][1]['rel'] == 'data'
 
     qs = "/wmtscache/collections"
     rv = client.get(qs)
@@ -47,6 +50,9 @@ def test_wmts_cachemngrapi_empty_cache(client):
     assert 'collections' in json_content
     assert len(json_content['collections']) == 0
     assert 'links' in json_content
+    assert len(json_content['links']) == 1
+    assert json_content['links'][0]['title'] == 'WMTS Cache manager Collections as JSON'
+    assert json_content['links'][0]['rel'] == 'self'
 
 
 def test_wmts_cachemngrapi_cache_info(client):
@@ -112,7 +118,7 @@ def test_wmts_cachemngrapi_cache_info(client):
         "TILEMATRIX": "0",
         "TILEROW": "0",
         "TILECOL": "0",
-        "FORMAT": "image/png" 
+        "FORMAT": "image/png"
     }
 
     # Get the cached path from the request parameters
@@ -148,7 +154,9 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert len(json_content['collections']) == 1
 
     assert 'links' in json_content
-    assert len(json_content['links']) == 0
+    assert len(json_content['links']) == 1
+    assert json_content['links'][0]['title'] == 'WMTS Cache manager Collections as JSON'
+    assert json_content['links'][0]['rel'] == 'self'
 
     collection = json_content['collections'][0]
     assert 'id' in collection
@@ -169,7 +177,9 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert json_content['project'] == client.getprojectpath("france_parts.qgs").strpath
 
     assert 'links' in json_content
-    assert len(json_content['links']) == 2
+    assert len(json_content['links']) == 3
+    assert json_content['links'][0]['title'] == 'WMTS Cache manager ProjectCollection as JSON'
+    assert json_content['links'][0]['rel'] == 'self'
 
     qs = "/wmtscache/collections/{}/docs".format(collection['id'])
     rv = client.get(qs)
@@ -187,7 +197,9 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert json_content['documents'] == 1
 
     assert 'links' in json_content
-    assert len(json_content['links']) == 0
+    assert len(json_content['links']) == 1
+    assert json_content['links'][0]['title'] == 'WMTS Cache manager DocumentCollection as JSON'
+    assert json_content['links'][0]['rel'] == 'self'
 
     qs = "/wmtscache/collections/{}/layers".format(collection['id'])
     rv = client.get(qs)
@@ -205,7 +217,9 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert len(json_content['layers']) == 1
 
     assert 'links' in json_content
-    assert len(json_content['links']) == 0
+    assert len(json_content['links']) == 1
+    assert json_content['links'][0]['title'] == 'WMTS Cache manager LayerCollection as JSON'
+    assert json_content['links'][0]['rel'] == 'self'
 
     layer = json_content['layers'][0]
     assert 'id' in layer
@@ -221,7 +235,9 @@ def test_wmts_cachemngrapi_cache_info(client):
     assert json_content['id'] == layer['id']
 
     assert 'links' in json_content
-    assert len(json_content['links']) == 0
+    assert len(json_content['links']) == 1
+    assert json_content['links'][0]['title'] == 'WMTS Cache manager LayerCache as JSON'
+    assert json_content['links'][0]['rel'] == 'self'
 
 
 def test_wmts_cachemngrapi_delete_docs(client):
@@ -356,7 +372,7 @@ def test_wmts_cachemngrapi_delete_layer(client):
         "TILEMATRIX": "0",
         "TILEROW": "0",
         "TILECOL": "0",
-        "FORMAT": "image/png" 
+        "FORMAT": "image/png"
     }
 
     # Get the cached path from the request parameters
@@ -478,7 +494,7 @@ def test_wmts_cachemngrapi_delete_layers(client):
         "TILEMATRIX": "0",
         "TILEROW": "0",
         "TILECOL": "0",
-        "FORMAT": "image/png" 
+        "FORMAT": "image/png"
     }
 
     # Get the cached path from the request parameters
@@ -610,7 +626,7 @@ def test_wmts_cachemngrapi_delete_collection(client):
         "TILEMATRIX": "0",
         "TILEROW": "0",
         "TILECOL": "0",
-        "FORMAT": "image/png" 
+        "FORMAT": "image/png"
     }
 
     # Get the cached path from the request parameters
@@ -746,7 +762,7 @@ def test_wmts_cachemngrapi_layerid_error(client):
         "TILEMATRIX": "0",
         "TILEROW": "0",
         "TILECOL": "0",
-        "FORMAT": "image/png" 
+        "FORMAT": "image/png"
     }
 
     # Get the cached path from the request parameters

--- a/wmtsCacheServer/apiutils.py
+++ b/wmtsCacheServer/apiutils.py
@@ -64,7 +64,7 @@ class RequestHandler:
         pass
 
     def href(self, path: str="", extension: str="") -> str:
-        """ Returns an URL to self, to be used for links to the current resources 
+        """ Returns an URL to self, to be used for links to the current resources
             and as a base for constructing links to sub-resources
         """
         return self._parent.href(self._context,path,extension)
@@ -113,10 +113,10 @@ class RequestHandler:
         self.write(dict(status="error" if status_code != 200 else "ok",
                         httpcode = status_code,
                         error    = { "message": self._reason }))
-        
+
         if status_code > 300:
             QgsMessageLog.logMessage(f"Returned HTTP Error {status_code}: {self._reason}" ,"wmtsCacheApi",Qgis.Critical)
-        
+
         if not self._finished:
             self.finish()
 
@@ -181,7 +181,7 @@ class RequestHandlerDelegate(QgsServerOgcApiHandler):
     """
 
     # XXX We need to preserve instances from garbage
-    # collection 
+    # collection
     __instances = []
 
     def __init__(self, path: str, handler: Type[RequestHandler],
@@ -189,14 +189,21 @@ class RequestHandlerDelegate(QgsServerOgcApiHandler):
                  kwargs: Dict={}):
 
         super().__init__()
+        self._content_types = []
         if content_types:
             self.setContentTypes(content_types)
+            self._content_types = content_types
         self._path = QRegularExpression(path)
         self._name = handler.__name__
         self._handler = handler
         self._kwargs = kwargs
 
         self.__instances.append(self)
+
+    def contentTypes(self):
+        """ QgsServerOgcApiHandler::contentTypes not available in Python bindings
+        """
+        return self._content_types
 
     def path(self):
         return self._path
@@ -224,7 +231,7 @@ class RequestHandlerDelegate(QgsServerOgcApiHandler):
         return []
 
     def handleRequest(self, context):
-        """ 
+        """
         """
         handler = self._handler(self,context)
         handler.initialize(**self._kwargs)

--- a/wmtsCacheServer/apiutils.py
+++ b/wmtsCacheServer/apiutils.py
@@ -67,7 +67,22 @@ class RequestHandler:
         """ Returns an URL to self, to be used for links to the current resources
             and as a base for constructing links to sub-resources
         """
-        return self._parent.href(self._context,path,extension)
+        return self._parent.href(self._context, path, extension)
+
+    def links(self) -> List[str]:
+        """Returns the self and alternate links for the given request
+           QgsServerOgcApiHandler::links not available in Python bindings
+        """
+        links = list()
+        current_ct = self._parent.contentTypeFromRequest(self._request)
+        for ct in self._parent.contentTypes():
+            links.append({
+                'href': self.href('', QgsServerOgcApi.contentTypeToExtension(ct) if ct != QgsServerOgcApi.JSON else ''),
+                'rel': QgsServerOgcApi.relToString(QgsServerOgcApi.self if ct == current_ct else QgsServerOgcApi.alternate),
+                "type": QgsServerOgcApi.mimeType(ct),
+                "title": self._parent.linkTitle()+' as '+QgsServerOgcApi.contentTypeToString(ct),
+            })
+        return links
 
     def finish(self, chunk: Optional[Union[str, bytes, dict]] = None) -> None:
         """ Terminate the request


### PR DESCRIPTION
To provide self and alternate links the RequestHandlerDelegate.contentTypes and RequestHandler.links have been implemented because QgsServerOgcApiHandler::contentTypes and QgsServerOgcApiHandler::links are not available in Python bindings.

This PR is an extraction of #7